### PR TITLE
feat(bot): трёхцветная индикация статуса + handshake в списке (#21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ Format — [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioning 
   настройках. Действует на одиночное и массовое добавление.
 - **Карточка клиента**: отдельные кнопки для конфига, QR, ссылки и «всё»
   (раньше — одна кнопка «всё»).
+- **Трёхцветная индикация статуса**: 🟢 активен/недавно, 🟡 нет handshake
+  (никогда не подключался), 🔴 оффлайн/ошибка ключа — вместо прежнего
+  бинарного «зелёный/красный». Время последнего handshake теперь прямо в
+  кнопке списка клиентов; карточка перерисована в иконочном формате
+  ([#21](https://github.com/ekuraev/awgram/issues/21)).
 
 ### 🇬🇧 English
 
@@ -30,6 +35,11 @@ Format — [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioning 
   Applies to both single and bulk addition.
 - **Client card**: separate buttons for config, QR, link and "all"
   (previously a single "all" button).
+- **Three-color status indicators**: 🟢 active/recent, 🟡 no handshake
+  (never connected), 🔴 offline/key error — replacing the former binary
+  "green/red". Last handshake time now shown directly in the client list
+  button; the card was restyled to an icon-based layout
+  ([#21](https://github.com/ekuraev/awgram/issues/21)).
 
 ## [0.5.0] — 2026-07-28
 

--- a/src/bot/handlers.rs
+++ b/src/bot/handlers.rs
@@ -799,7 +799,9 @@ async fn callback_handler(
             )
             .await;
         }
-        Action::List => match vpn.list().await {
+        Action::List => match vpn.stats().await {
+            // stats --json вместо list: кнопки списка показывают handshake
+            // (last_handshake есть только в stats; list отдаёт лишь status_code).
             Ok(clients) if clients.is_empty() => {
                 edit_or_send(
                     &bot,
@@ -826,11 +828,14 @@ async fn callback_handler(
                 .await;
             }
             Err(e) => {
-                tracing::error!(error = %e, "list провалился");
+                tracing::error!(error = %e, "stats провалился");
                 bot.send_message(chat, i18n::error_text(lang, &e)).await?;
             }
         },
-        Action::Page(p) => match vpn.list().await {
+        Action::Page(p) => match vpn.stats().await {
+            // stats --json (см. Action::List): handshake в кнопках требует
+            // last_handshake, которого нет в list. refresh перерисовывает
+            // текущую страницу p со свежими данными.
             // Пустой список (напр. всех клиентов удалили, пока смотрели страницу) —
             // показываем friendly-сообщение, как в Action::List, а не пустую страницу.
             Ok(clients) if clients.is_empty() => {

--- a/src/bot/menu.rs
+++ b/src/bot/menu.rs
@@ -795,11 +795,15 @@ mod tests {
         ];
         let texts = all_button_texts(&clients_list(Lang::Ru, &clients, &[], now, 0, 10));
         assert!(
-            texts.iter().any(|t| t.contains("recent") && t.contains("10 мин")),
+            texts
+                .iter()
+                .any(|t| t.contains("recent") && t.contains("10 мин")),
             "recent должен показывать handshake: {texts:?}"
         );
         assert!(
-            texts.iter().any(|t| t.contains("fresh") && t.contains("никогда")),
+            texts
+                .iter()
+                .any(|t| t.contains("fresh") && t.contains("никогда")),
             "fresh (last_handshake=0) должен показывать «никогда»: {texts:?}"
         );
     }

--- a/src/bot/menu.rs
+++ b/src/bot/menu.rs
@@ -1,7 +1,7 @@
 use teloxide::types::{InlineKeyboardButton, InlineKeyboardMarkup};
 
 use crate::i18n::{self, Lang};
-use crate::vpn::model::Client;
+use crate::vpn::model::{format_handshake_compact, Client};
 use crate::vpn::BackupFile;
 
 fn cb(text: &str, data: &str) -> InlineKeyboardButton {
@@ -234,11 +234,14 @@ pub fn clients_list(
         .skip(start)
         .take(per_page)
         .map(|(i, c)| {
-            let mark = if c.active() { "🟢" } else { "🔴" };
+            let mark = c.status_mark();
+            // Компактный handshake («2 мин», «никогда») — требуется stats()
+            // (last_handshake есть только в stats --json, не в list --json).
+            let hs = format_handshake_compact(lang, now, c.last_handshake.unwrap_or(0));
             let exp = expiries.get(i).copied().flatten();
             let label = match crate::vpn::model::format_expiry_badge(lang, now, exp) {
-                Some(badge) => format!("{mark} {} {badge}", c.name),
-                None => format!("{mark} {}", c.name),
+                Some(badge) => format!("{mark} {} · {hs} {badge}", c.name),
+                None => format!("{mark} {} · {hs}", c.name),
             };
             vec![cb(&label, &format!("client:{}", c.name))]
         })
@@ -246,7 +249,8 @@ pub fn clients_list(
 
     let total_pages = clients.len().div_ceil(per_page).max(1);
     // 🔄 всегда в nav-ряду: перерисовывает ТЕКУЩУЮ страницу со свежими данными.
-    // Callback `page:{page}` → Action::Page (он заново зовёт vpn.list()), поэтому
+    // Callback `page:{page}` → Action::Page (он заново зовёт vpn.stats() —
+    // список переключён на stats ради last_handshake в кнопках), поэтому
     // refresh сохраняет страницу, а не сбрасывает на 0. На одностраничном списке
     // это единственная кнопка ряда; на многостраничном встаёт между пагинацией:
     // [◀️] [🔄] [▶️].
@@ -708,6 +712,95 @@ mod tests {
                 .iter()
                 .any(|t| t.contains("perm") && !t.contains("⏳")),
             "perm должен быть без метки: {texts:?}"
+        );
+    }
+
+    #[test]
+    fn clients_list_three_color_marks_by_status_code() {
+        // 🟢 active / 🟡 no_handshake / 🔴 inactive — трёхцветная индикация
+        // вместо прежнего бинарного active→🟢 / всё прочее→🔴.
+        let clients = vec![
+            Client {
+                name: "online".into(),
+                ip: String::new(),
+                client_ipv6: String::new(),
+                status: String::new(),
+                status_code: "active".into(),
+                rx: 0,
+                tx: 0,
+                last_handshake: None,
+            },
+            Client {
+                name: "never".into(),
+                ip: String::new(),
+                client_ipv6: String::new(),
+                status: String::new(),
+                status_code: "no_handshake".into(),
+                rx: 0,
+                tx: 0,
+                last_handshake: None,
+            },
+            Client {
+                name: "gone".into(),
+                ip: String::new(),
+                client_ipv6: String::new(),
+                status: String::new(),
+                status_code: "inactive".into(),
+                rx: 0,
+                tx: 0,
+                last_handshake: None,
+            },
+        ];
+        let texts = all_button_texts(&clients_list(Lang::Ru, &clients, &[], 0, 0, 10));
+        assert!(
+            texts.iter().any(|t| t.starts_with("🟢 online")),
+            "active должен быть зелёным: {texts:?}"
+        );
+        assert!(
+            texts.iter().any(|t| t.starts_with("🟡 never")),
+            "no_handshake должен быть жёлтым: {texts:?}"
+        );
+        assert!(
+            texts.iter().any(|t| t.starts_with("🔴 gone")),
+            "inactive должен быть красным: {texts:?}"
+        );
+    }
+
+    #[test]
+    fn clients_list_shows_compact_handshake() {
+        // handshake в кнопке — компактно («10 мин», «никогда»); last_handshake
+        // приходит из stats --json (экран списка переключён на stats).
+        let now = 1_700_000_000;
+        let clients = vec![
+            Client {
+                name: "recent".into(),
+                ip: String::new(),
+                client_ipv6: String::new(),
+                status: String::new(),
+                status_code: "active".into(),
+                rx: 0,
+                tx: 0,
+                last_handshake: Some(now - 600),
+            },
+            Client {
+                name: "fresh".into(),
+                ip: String::new(),
+                client_ipv6: String::new(),
+                status: String::new(),
+                status_code: "no_handshake".into(),
+                rx: 0,
+                tx: 0,
+                last_handshake: Some(0),
+            },
+        ];
+        let texts = all_button_texts(&clients_list(Lang::Ru, &clients, &[], now, 0, 10));
+        assert!(
+            texts.iter().any(|t| t.contains("recent") && t.contains("10 мин")),
+            "recent должен показывать handshake: {texts:?}"
+        );
+        assert!(
+            texts.iter().any(|t| t.contains("fresh") && t.contains("никогда")),
+            "fresh (last_handshake=0) должен показывать «никогда»: {texts:?}"
         );
     }
 

--- a/src/bot/render.rs
+++ b/src/bot/render.rs
@@ -10,6 +10,7 @@ pub fn format_client_card(lang: Lang, c: &Client, now: i64, expiry: Option<i64>)
     i18n::client_card(
         lang,
         &c.name,
+        &c.status_code,
         &status,
         &c.ip,
         &human_bytes(c.rx),

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -380,6 +380,7 @@ pub fn link_unavailable(lang: Lang) -> String {
 pub fn client_card(
     lang: Lang,
     name: &str,
+    status_code: &str,
     status: &str,
     ip: &str,
     rx: &str,
@@ -388,17 +389,18 @@ pub fn client_card(
     expires: &str,
 ) -> String {
     let (name, status, ip) = (html_escape(name), html_escape(status), html_escape(ip));
+    let mark = crate::vpn::model::status_mark_code(status_code);
     let ip_line = if ip.is_empty() {
         String::new()
     } else {
         match lang {
-            Lang::Ru => format!("IP: {ip}\n"),
-            Lang::En => format!("IP: {ip}\n"),
+            Lang::Ru => format!("🌐 IP: {ip}\n"),
+            Lang::En => format!("🌐 IP: {ip}\n"),
         }
     };
     match lang {
-        Lang::Ru => format!("👤 <b>{name}</b>\nСтатус: {status}\n{ip_line}Трафик:  ↓ {rx}   ↑ {tx}\nРукопожатие: {handshake}\nДействует: {expires}"),
-        Lang::En => format!("👤 <b>{name}</b>\nStatus: {status}\n{ip_line}Traffic:  ↓ {rx}   ↑ {tx}\nHandshake: {handshake}\nExpires: {expires}"),
+        Lang::Ru => format!("👤 <b>{name}</b>\n{mark} Статус: {status}\n{ip_line}📊 Трафик:  ↓ {rx} · ↑ {tx}\n⏱ Рукопожатие: {handshake}\n📅 Действует: {expires}"),
+        Lang::En => format!("👤 <b>{name}</b>\n{mark} Status: {status}\n{ip_line}📊 Traffic:  ↓ {rx} · ↑ {tx}\n⏱ Handshake: {handshake}\n📅 Expires: {expires}"),
     }
 }
 pub fn stats_summary(lang: Lang, total: usize, active: usize, rx: &str, tx: &str) -> String {
@@ -1089,6 +1091,7 @@ mod tests {
             let card = client_card(
                 l,
                 "a<b>",
+                "active",
                 "Активен",
                 "10.0.0.2",
                 "1 KB",
@@ -1098,6 +1101,7 @@ mod tests {
             );
             assert!(card.contains("a&lt;b&gt;"));
             assert!(!card.contains("a<b>"));
+            assert!(card.contains("🟢")); // цвет статуса по status_code
         }
     }
 

--- a/src/vpn/model.rs
+++ b/src/vpn/model.rs
@@ -446,8 +446,14 @@ mod tests {
 
     #[test]
     fn format_handshake_compact_never() {
-        assert_eq!(format_handshake_compact(Lang::Ru, 1_700_000_000, 0), "никогда");
-        assert_eq!(format_handshake_compact(Lang::En, 1_700_000_000, -5), "never");
+        assert_eq!(
+            format_handshake_compact(Lang::Ru, 1_700_000_000, 0),
+            "никогда"
+        );
+        assert_eq!(
+            format_handshake_compact(Lang::En, 1_700_000_000, -5),
+            "never"
+        );
     }
 
     #[test]
@@ -474,7 +480,10 @@ mod tests {
     #[test]
     fn format_handshake_compact_days() {
         let now = 1_700_000_000;
-        assert_eq!(format_handshake_compact(Lang::Ru, now, now - 172800), "2 дн");
+        assert_eq!(
+            format_handshake_compact(Lang::Ru, now, now - 172800),
+            "2 дн"
+        );
         assert_eq!(format_handshake_compact(Lang::En, now, now - 172800), "2 d");
     }
 

--- a/src/vpn/model.rs
+++ b/src/vpn/model.rs
@@ -25,6 +25,26 @@ impl Client {
     pub fn active(&self) -> bool {
         self.status_code == "active"
     }
+
+    /// Трёхцветная метка статуса для индикации в списке и карточке.
+    /// Опирается на стабильный `status_code` инсталлера (а не на handshake):
+    /// инсталлер уже считает эти градации корректно с учётом keepalive/недавности.
+    ///   🟢 `active` / `recent`      — подключён / был недавно
+    ///   🟡 `no_handshake` / `no_data` — никогда не подключался / нет данных
+    ///   🔴 прочее (`inactive`/`key_error`/...) — был, но давно / ошибка ключа
+    pub fn status_mark(&self) -> &'static str {
+        status_mark_code(&self.status_code)
+    }
+}
+
+/// Цвет статуса по строковому `status_code`. Вынесен из `Client::status_mark`,
+/// чтобы слой `i18n` мог выбрать эмодзи для карточки без владения `Client`.
+pub fn status_mark_code(status_code: &str) -> &'static str {
+    match status_code {
+        "active" | "recent" => "🟢",
+        "no_handshake" | "no_data" => "🟡",
+        _ => "🔴",
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -124,6 +144,43 @@ pub fn format_handshake(lang: Lang, now: i64, hs: i64) -> String {
         match lang {
             Lang::Ru => format!("{} дн назад", d / 86400),
             Lang::En => format!("{} d ago", d / 86400),
+        }
+    }
+}
+
+/// Компактная метка handshake для кнопки списка («5 мин», а не «5 мин назад»).
+/// Те же пороги, что у `format_handshake`, но без хвоста «назад»/«ago» — кнопки
+/// Telegram узкие, и каждая морфема на счету. `hs <= 0` → «никогда»/«never»
+/// (клиент с `no_handshake` по `status_code` плюс никогда не имевший handshake).
+pub fn format_handshake_compact(lang: Lang, now: i64, hs: i64) -> String {
+    if hs <= 0 {
+        return match lang {
+            Lang::Ru => "никогда",
+            Lang::En => "never",
+        }
+        .to_string();
+    }
+    let d = now - hs;
+    if d < 60 {
+        match lang {
+            Lang::Ru => "сейчас",
+            Lang::En => "now",
+        }
+        .to_string()
+    } else if d < 3600 {
+        match lang {
+            Lang::Ru => format!("{} мин", d / 60),
+            Lang::En => format!("{} min", d / 60),
+        }
+    } else if d < 86400 {
+        match lang {
+            Lang::Ru => format!("{} ч", d / 3600),
+            Lang::En => format!("{} h", d / 3600),
+        }
+    } else {
+        match lang {
+            Lang::Ru => format!("{} дн", d / 86400),
+            Lang::En => format!("{} d", d / 86400),
         }
     }
 }
@@ -382,6 +439,89 @@ mod tests {
             format_handshake(Lang::Ru, 1_700_000_000, 1_700_000_100),
             "только что"
         );
+    }
+
+    // --- format_handshake_compact: те же пороги, что у format_handshake,
+    // но без хвоста «назад»/«ago» — для узких кнопок списка клиентов. ---
+
+    #[test]
+    fn format_handshake_compact_never() {
+        assert_eq!(format_handshake_compact(Lang::Ru, 1_700_000_000, 0), "никогда");
+        assert_eq!(format_handshake_compact(Lang::En, 1_700_000_000, -5), "never");
+    }
+
+    #[test]
+    fn format_handshake_compact_now() {
+        let now = 1_700_000_000;
+        assert_eq!(format_handshake_compact(Lang::Ru, now, now - 30), "сейчас");
+        assert_eq!(format_handshake_compact(Lang::En, now, now + 10), "now");
+    }
+
+    #[test]
+    fn format_handshake_compact_minutes() {
+        let now = 1_700_000_000;
+        assert_eq!(format_handshake_compact(Lang::Ru, now, now - 600), "10 мин");
+        assert_eq!(format_handshake_compact(Lang::En, now, now - 600), "10 min");
+    }
+
+    #[test]
+    fn format_handshake_compact_hours() {
+        let now = 1_700_000_000;
+        assert_eq!(format_handshake_compact(Lang::Ru, now, now - 7200), "2 ч");
+        assert_eq!(format_handshake_compact(Lang::En, now, now - 7200), "2 h");
+    }
+
+    #[test]
+    fn format_handshake_compact_days() {
+        let now = 1_700_000_000;
+        assert_eq!(format_handshake_compact(Lang::Ru, now, now - 172800), "2 дн");
+        assert_eq!(format_handshake_compact(Lang::En, now, now - 172800), "2 d");
+    }
+
+    #[test]
+    fn format_handshake_compact_boundary_60_seconds() {
+        let now = 2_000_000;
+        assert_eq!(format_handshake_compact(Lang::Ru, now, now - 60), "1 мин");
+    }
+
+    // --- status_mark_code: трёхцветная карта по status_code инсталлера. ---
+
+    #[test]
+    fn status_mark_green_for_active_and_recent() {
+        assert_eq!(status_mark_code("active"), "🟢");
+        assert_eq!(status_mark_code("recent"), "🟢");
+    }
+
+    #[test]
+    fn status_mark_yellow_for_no_handshake_and_no_data() {
+        // Клиент, который НИКОГДА не подключался / нет данных — отличается от
+        // «был, но давно»: жёлтый, а не красный.
+        assert_eq!(status_mark_code("no_handshake"), "🟡");
+        assert_eq!(status_mark_code("no_data"), "🟡");
+    }
+
+    #[test]
+    fn status_mark_red_for_inactive_key_error_and_unknown() {
+        assert_eq!(status_mark_code("inactive"), "🔴");
+        assert_eq!(status_mark_code("key_error"), "🔴");
+        // Неизвестный код в будущей версии инсталлера — безопасный дефолт красный.
+        assert_eq!(status_mark_code("totally_new_code"), "🔴");
+        assert_eq!(status_mark_code(""), "🔴");
+    }
+
+    #[test]
+    fn client_status_mark_matches_helper() {
+        let c = Client {
+            name: "x".into(),
+            ip: String::new(),
+            client_ipv6: String::new(),
+            status: String::new(),
+            status_code: "no_handshake".into(),
+            rx: 0,
+            tx: 0,
+            last_handshake: None,
+        };
+        assert_eq!(c.status_mark(), "🟡");
     }
 
     #[test]


### PR DESCRIPTION
## Что делает

Различает три состояния клиентов по `status_code` инсталлера вместо прежнего бинарного `active`→🟢 / прочее→🔴:

| Цвет | status_code | Значение |
|------|-------------|----------|
| 🟢 | `active` / `recent` | подключён / был недавно |
| 🟡 | `no_handshake` / `no_data` | никогда не подключался / нет данных |
| 🔴 | `inactive` / `key_error` | был, но давно / ошибка ключа |

Жёлтый для «никогда не было handshake» устраняет главную путаницу: такой клиент раньше выглядел как 🔴 (как и давно отключившийся), хотя для аудита неактивных клиентов это разные ситуации.

Дополнительно:
- **Handshake в кнопке списка** — компактно («2 мин», «никогда»), с разделителем `·` и бейджем срока: `🟢 alice · 2 мин ⏳6д`.
- **Карточка перерисована** в иконочном формате с цветным префиксом статуса.

## Технические детали

- `status_mark_code()` (`model.rs`) — карта `status_code`→эмодзи, общая для списка и карточки.
- `format_handshake_compact()` (`model.rs`) — компактная метка для узких кнопок (без хвоста «назад»).
- Экран списка (`Action::List`/`Action::Page`) переключён с `vpn.list()` на `vpn.stats()` — `last_handshake` есть только в `stats --json`. Контракт парсинга идентичен; `exists()` и проверку коллизий в `finish_bulk` не трогал (им handshake не нужен).
- Карточка получила `status_code` параметром для цветного эмодзи.

## Скоуп issue #21

- ✅ П.1 (статус) — по `status_code` инсталлера (надёжнее ручного порога handshake)
- ✅ П.2 (цвет в списке) — трёхцветие + handshake
- ✅ П.3 (карточка) — эмодзи-рестайлинг
- ⚠️ 🌐 Endpoint — инсталлер не отдаёт это поле ни в `list`, ни в `stats`
- 🔸 П.4 (фильтр онлайн/оффлайн + сортировка) — отдельный PR, чтобы этот остался компактным

## Проверка

- `cargo test`: 254 unit + 4 integration, всё зелёное
- `cargo clippy --all-targets -- -D warnings`: чисто

Closes #21 (частично).