### PR TITLE
feat(bot): фильтр и сортировка списка клиентов (#28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ Format — [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioning 
   бинарного «зелёный/красный». Время последнего handshake теперь прямо в
   кнопке списка клиентов; карточка перерисована в иконочном формате
   ([#21](https://github.com/ekuraev/awgram/issues/21)).
+- **Фильтр и сортировка списка клиентов**: кнопки фильтра по статусу
+  (Все / 🟢 Онлайн / 🔴 Оффлайн / 🟡 Никогда) и сортировка «онлайн вперёд»
+  (🟢 → 🔴 → 🟡, внутри группы — по имени). Выбранный фильтр сохраняется
+  между сессиями и отображается в заголовке списка
+  ([#28](https://github.com/ekuraev/awgram/issues/28)).
 
 ### 🇬🇧 English
 
@@ -40,6 +45,11 @@ Format — [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioning 
   "green/red". Last handshake time now shown directly in the client list
   button; the card was restyled to an icon-based layout
   ([#21](https://github.com/ekuraev/awgram/issues/21)).
+- **Client list filter and sort**: status filter buttons
+  (All / 🟢 Online / 🔴 Offline / 🟡 Never) and "online-first" sorting
+  (🟢 → 🔴 → 🟡, by name within a group). The selected filter persists
+  across sessions and is shown in the list title
+  ([#28](https://github.com/ekuraev/awgram/issues/28)).
 
 ## [0.5.0] — 2026-07-28
 

--- a/src/bot/handlers.rs
+++ b/src/bot/handlers.rs
@@ -63,6 +63,8 @@ pub enum Action {
     SetConf(bool),
     SetQr(bool),
     SetLink(bool),
+    // --- Фильтр списка клиентов (#28) ---
+    SetListFilter(crate::vpn::model::ClientFilter),
     Unknown,
 }
 
@@ -142,6 +144,12 @@ fn parse_callback(data: &str) -> Action {
                 Action::SetQr(v == "on")
             } else if let Some(v) = data.strip_prefix("set:link:") {
                 Action::SetLink(v == "on")
+            } else if let Some(v) = data.strip_prefix("listfilter:") {
+                // Фильтр списка клиентов (#28). "list" — точный match выше (не
+                // префикс), так что listfilter: с ним не коллизирует.
+                crate::vpn::model::ClientFilter::parse_str(v)
+                    .map(Action::SetListFilter)
+                    .unwrap_or(Action::Unknown)
             } else if let Some(v) = data.strip_prefix("lang:") {
                 Action::Lang(v.to_string())
             } else if let Some(v) = data.strip_prefix("bk:restore_yes:") {
@@ -753,6 +761,58 @@ async fn finish_bulk(
     }
 }
 
+/// Рендерит экран списка клиентов: stats → filter+sort → expiries → title →
+/// clients_list. Общая логика для Action::List / Action::Page / Action::SetListFilter
+/// (различаются только страницей и тем, кто читает/устанавливает фильтр из настроек).
+/// Пустой список (до или после фильтра) → friendly-сообщение + главное меню.
+async fn render_clients_list(
+    bot: &Bot,
+    chat: ChatId,
+    msg_id: MessageId,
+    lang: Lang,
+    vpn: &Vpn,
+    settings: &SettingsStore,
+    page: usize,
+) {
+    match vpn.stats().await {
+        Ok(all_clients) => {
+            // Фильтр + сортировка «онлайн вперёд» (🟢 → 🔴 → 🟡, внутри — по имени).
+            // apply_filter_and_sort возвращает owned Vec — clients_list берёт срез по странице.
+            let filter = settings.client_filter();
+            let clients = crate::vpn::model::apply_filter_and_sort(&all_clients, filter);
+            if clients.is_empty() {
+                edit_or_send(
+                    bot,
+                    chat,
+                    msg_id,
+                    i18n::clients_empty(lang),
+                    menu::main_menu(lang),
+                )
+                .await;
+                return;
+            }
+            // Полный вектор (не страница): clients_list индексирует expiries[i]
+            // по глобальному i, срез по странице дал бы сдвиг меток на страницах > 0.
+            let expiries: Vec<Option<i64>> =
+                clients.iter().map(|c| vpn.client_expiry(&c.name)).collect();
+            let title =
+                i18n::clients_title_filtered(lang, filter, clients.len(), all_clients.len());
+            edit_or_send(
+                bot,
+                chat,
+                msg_id,
+                title,
+                menu::clients_list(lang, &clients, &expiries, now_epoch(), page, 8, filter),
+            )
+            .await;
+        }
+        Err(e) => {
+            tracing::error!(error = %e, "stats провалился");
+            let _ = bot.send_message(chat, i18n::error_text(lang, &e)).await;
+        }
+    }
+}
+
 async fn callback_handler(
     bot: Bot,
     dialogue: MyDialogue,
@@ -799,72 +859,16 @@ async fn callback_handler(
             )
             .await;
         }
-        Action::List => match vpn.stats().await {
-            // stats --json вместо list: кнопки списка показывают handshake
-            // (last_handshake есть только в stats; list отдаёт лишь status_code).
-            Ok(clients) if clients.is_empty() => {
-                edit_or_send(
-                    &bot,
-                    chat,
-                    msg_id,
-                    i18n::clients_empty(lang),
-                    menu::main_menu(lang),
-                )
-                .await;
-            }
-            Ok(clients) => {
-                // Полный вектор (не только текущая страница): clients_list
-                // индексирует expiries[i] по глобальному i, срез по странице
-                // дал бы сдвиг меток на страницах > 0.
-                let expiries: Vec<Option<i64>> =
-                    clients.iter().map(|c| vpn.client_expiry(&c.name)).collect();
-                edit_or_send(
-                    &bot,
-                    chat,
-                    msg_id,
-                    i18n::clients_title(lang),
-                    menu::clients_list(lang, &clients, &expiries, now_epoch(), 0, 8),
-                )
-                .await;
-            }
-            Err(e) => {
-                tracing::error!(error = %e, "stats провалился");
-                bot.send_message(chat, i18n::error_text(lang, &e)).await?;
-            }
-        },
-        Action::Page(p) => match vpn.stats().await {
-            // stats --json (см. Action::List): handshake в кнопках требует
-            // last_handshake, которого нет в list. refresh перерисовывает
-            // текущую страницу p со свежими данными.
-            // Пустой список (напр. всех клиентов удалили, пока смотрели страницу) —
-            // показываем friendly-сообщение, как в Action::List, а не пустую страницу.
-            Ok(clients) if clients.is_empty() => {
-                edit_or_send(
-                    &bot,
-                    chat,
-                    msg_id,
-                    i18n::clients_empty(lang),
-                    menu::main_menu(lang),
-                )
-                .await;
-            }
-            Ok(clients) => {
-                // См. комментарий в Action::List: вектор обязан быть полным.
-                let expiries: Vec<Option<i64>> =
-                    clients.iter().map(|c| vpn.client_expiry(&c.name)).collect();
-                edit_or_send(
-                    &bot,
-                    chat,
-                    msg_id,
-                    i18n::clients_title(lang),
-                    menu::clients_list(lang, &clients, &expiries, now_epoch(), p, 8),
-                )
-                .await;
-            }
-            Err(e) => {
-                bot.send_message(chat, i18n::error_text(lang, &e)).await?;
-            }
-        },
+        Action::List => {
+            // Экран списка: stats → filter+sort (фильтр из настроек) → рендер.
+            // Фильтр/сортировку см. render_clients_list.
+            render_clients_list(&bot, chat, msg_id, lang, &vpn, &settings, 0).await;
+        }
+        Action::Page(p) => {
+            // Пагинация: тот же рендер, но страница p. Фильтр из настроек —
+            // переживает навигацию по страницам (Action::Page его не меняет).
+            render_clients_list(&bot, chat, msg_id, lang, &vpn, &settings, p).await;
+        }
         Action::Stats => match vpn.stats().await {
             Ok(clients) => {
                 edit_or_send(
@@ -1356,6 +1360,13 @@ async fn callback_handler(
             settings.set_deliver_link(on);
             show_settings(&bot, chat, msg_id, lang, &settings).await;
         }
+        Action::SetListFilter(f) => {
+            // Сохраняем фильтр персистентно, затем перерисовываем список с
+            // НУЛЕВОЙ страницей — содержимое сменилось, старая страница могла
+            // стать невалидной (напр. был на стр.2 оффлайн, переключил на онлайн).
+            settings.set_client_filter(f);
+            render_clients_list(&bot, chat, msg_id, lang, &vpn, &settings, 0).await;
+        }
         Action::Backup => {
             edit_or_send(
                 &bot,
@@ -1615,6 +1626,40 @@ mod tests {
     }
 
     #[test]
+    fn parse_callback_listfilter_variants() {
+        use crate::vpn::model::ClientFilter;
+        assert_eq!(
+            parse_callback("listfilter:all"),
+            Action::SetListFilter(ClientFilter::All)
+        );
+        assert_eq!(
+            parse_callback("listfilter:online"),
+            Action::SetListFilter(ClientFilter::Online)
+        );
+        assert_eq!(
+            parse_callback("listfilter:offline"),
+            Action::SetListFilter(ClientFilter::Offline)
+        );
+        assert_eq!(
+            parse_callback("listfilter:never"),
+            Action::SetListFilter(ClientFilter::Never)
+        );
+        // Неизвестное значение фильтра → Unknown (craftable callback guard).
+        assert_eq!(parse_callback("listfilter:garbage"), Action::Unknown);
+    }
+
+    #[test]
+    fn parse_callback_listfilter_does_not_collide_with_list() {
+        // "list" — точный match (Action::List), "listfilter:..." — префикс.
+        // Они не должны пересекаться.
+        assert_eq!(parse_callback("list"), Action::List);
+        assert!(matches!(
+            parse_callback("listfilter:all"),
+            Action::SetListFilter(_)
+        ));
+    }
+
+    #[test]
     fn parse_callback_diagnose() {
         assert_eq!(parse_callback("diagnose"), Action::Diagnose);
     }
@@ -1761,7 +1806,15 @@ mod tests {
             menu::client_card(Lang::Ru, "alice"),
             menu::confirm_delete(Lang::Ru, "bob"),
             menu::confirm_recreate(Lang::Ru, "alice"),
-            menu::clients_list(Lang::Ru, &[sample_client], &[], 0, 0, 8),
+            menu::clients_list(
+                Lang::Ru,
+                &[sample_client],
+                &[],
+                0,
+                0,
+                8,
+                crate::vpn::model::ClientFilter::All,
+            ),
             menu::language_select(),
             menu::settings_menu(Lang::Ru, false, false, false, false, false),
             menu::settings_menu(Lang::Ru, true, true, true, true, true),

--- a/src/bot/menu.rs
+++ b/src/bot/menu.rs
@@ -1,7 +1,7 @@
 use teloxide::types::{InlineKeyboardButton, InlineKeyboardMarkup};
 
 use crate::i18n::{self, Lang};
-use crate::vpn::model::{format_handshake_compact, Client};
+use crate::vpn::model::{format_handshake_compact, Client, ClientFilter};
 use crate::vpn::BackupFile;
 
 fn cb(text: &str, data: &str) -> InlineKeyboardButton {
@@ -215,6 +215,44 @@ pub fn bulk_psk_step(lang: Lang, default_on: bool) -> InlineKeyboardMarkup {
     ])
 }
 
+/// Ряд фильтра списка: [Все] [🟢 Онлайн] [🔴 Оффлайн] [🟡 Никогда].
+/// Активный фильтр помечается ✅-префиксом. Подписи локализуются здесь
+/// (как day_label), не входят в каталог i18n. Callback `listfilter:{as_str}`.
+fn filter_label(lang: Lang, f: ClientFilter) -> String {
+    let mark = f.mark();
+    let name = match (lang, f) {
+        (Lang::Ru, ClientFilter::All) => "Все",
+        (Lang::En, ClientFilter::All) => "All",
+        (Lang::Ru, ClientFilter::Online) => "Онлайн",
+        (Lang::En, ClientFilter::Online) => "Online",
+        (Lang::Ru, ClientFilter::Offline) => "Оффлайн",
+        (Lang::En, ClientFilter::Offline) => "Offline",
+        (Lang::Ru, ClientFilter::Never) => "Никогда",
+        (Lang::En, ClientFilter::Never) => "Never",
+    };
+    format!("{mark} {name}")
+}
+
+fn filter_row(lang: Lang, current: ClientFilter) -> Vec<InlineKeyboardButton> {
+    [
+        ClientFilter::All,
+        ClientFilter::Online,
+        ClientFilter::Offline,
+        ClientFilter::Never,
+    ]
+    .iter()
+    .map(|&f| {
+        // Активный фильтр помечается ✅ — кнопка-переключатель, неубираемый
+        // индикатор текущего режима просмотра списка.
+        let prefix = if f == current { "✅ " } else { "" };
+        cb(
+            &format!("{prefix}{}", filter_label(lang, f)),
+            &format!("listfilter:{}", f.as_str()),
+        )
+    })
+    .collect()
+}
+
 pub fn clients_list(
     lang: Lang,
     clients: &[Client],
@@ -222,6 +260,7 @@ pub fn clients_list(
     now: i64,
     page: usize,
     per_page: usize,
+    current_filter: ClientFilter,
 ) -> InlineKeyboardMarkup {
     if per_page == 0 {
         return InlineKeyboardMarkup::new(vec![vec![cb(&i18n::btn_back(lang), "menu")]]);
@@ -263,6 +302,7 @@ pub fn clients_list(
         nav.push(cb("▶️", &format!("page:{}", page + 1)));
     }
     rows.push(nav);
+    rows.push(filter_row(lang, current_filter));
     rows.push(vec![cb(&i18n::btn_regen_all(lang), "regen_all")]);
     rows.push(vec![cb(&i18n::btn_back(lang), "menu")]);
     InlineKeyboardMarkup::new(rows)
@@ -500,7 +540,15 @@ mod tests {
             tx: 0,
             last_handshake: None,
         }];
-        let data = all_callback_data(&clients_list(Lang::Ru, &clients, &[], 0, 0, 10));
+        let data = all_callback_data(&clients_list(
+            Lang::Ru,
+            &clients,
+            &[],
+            0,
+            0,
+            10,
+            ClientFilter::All,
+        ));
         assert!(data.contains(&"regen_all".to_string()));
     }
 
@@ -519,7 +567,15 @@ mod tests {
             tx: 0,
             last_handshake: None,
         }];
-        let data = all_callback_data(&clients_list(Lang::Ru, &clients, &[], 0, 0, 10));
+        let data = all_callback_data(&clients_list(
+            Lang::Ru,
+            &clients,
+            &[],
+            0,
+            0,
+            10,
+            ClientFilter::All,
+        ));
         assert!(
             data.contains(&"page:0".to_string()),
             "refresh button (page:0) missing: {data:?}"
@@ -541,7 +597,7 @@ mod tests {
                 last_handshake: None,
             })
             .collect();
-        let kb = clients_list(Lang::Ru, &clients, &[], 0, 0, 8);
+        let kb = clients_list(Lang::Ru, &clients, &[], 0, 0, 8, ClientFilter::All);
         // nav-ряд — первый после клиентских (8 клиентов на странице → ряд с индексом 8).
         let nav_row = &kb.inline_keyboard[8];
         let data: Vec<&str> = nav_row
@@ -572,7 +628,7 @@ mod tests {
                 last_handshake: None,
             })
             .collect();
-        let kb = clients_list(Lang::Ru, &clients, &[], 0, 2, 8);
+        let kb = clients_list(Lang::Ru, &clients, &[], 0, 2, 8, ClientFilter::All);
         // Страница 2: клиентские ряды 16..23 (8 шт.) → nav-ряд с индексом 8.
         let nav_row = &kb.inline_keyboard[8];
         let data: Vec<&str> = nav_row
@@ -625,7 +681,15 @@ mod tests {
                 last_handshake: None,
             },
         ];
-        let data = all_callback_data(&clients_list(Lang::Ru, &clients, &[], 0, 0, 10));
+        let data = all_callback_data(&clients_list(
+            Lang::Ru,
+            &clients,
+            &[],
+            0,
+            0,
+            10,
+            ClientFilter::All,
+        ));
         assert!(data.contains(&"client:a".to_string()));
         assert!(data.contains(&"client:b".to_string()));
     }
@@ -634,7 +698,7 @@ mod tests {
     fn clients_list_zero_per_page_no_panic() {
         // Test with empty clients
         let empty_clients: Vec<Client> = vec![];
-        let kb_empty = clients_list(Lang::Ru, &empty_clients, &[], 0, 0, 0);
+        let kb_empty = clients_list(Lang::Ru, &empty_clients, &[], 0, 0, 0, ClientFilter::All);
         let data_empty = all_callback_data(&kb_empty);
         assert_eq!(
             data_empty,
@@ -665,7 +729,7 @@ mod tests {
                 last_handshake: None,
             },
         ];
-        let kb_filled = clients_list(Lang::Ru, &clients, &[], 0, 0, 0);
+        let kb_filled = clients_list(Lang::Ru, &clients, &[], 0, 0, 0, ClientFilter::All);
         let data_filled = all_callback_data(&kb_filled);
         assert_eq!(
             data_filled,
@@ -700,7 +764,15 @@ mod tests {
         ];
         let now = 1_700_000_000;
         let expiries = vec![Some(now + 6 * 86400), None];
-        let texts = all_button_texts(&clients_list(Lang::Ru, &clients, &expiries, now, 0, 10));
+        let texts = all_button_texts(&clients_list(
+            Lang::Ru,
+            &clients,
+            &expiries,
+            now,
+            0,
+            10,
+            ClientFilter::All,
+        ));
         assert!(
             texts
                 .iter()
@@ -751,7 +823,15 @@ mod tests {
                 last_handshake: None,
             },
         ];
-        let texts = all_button_texts(&clients_list(Lang::Ru, &clients, &[], 0, 0, 10));
+        let texts = all_button_texts(&clients_list(
+            Lang::Ru,
+            &clients,
+            &[],
+            0,
+            0,
+            10,
+            ClientFilter::All,
+        ));
         assert!(
             texts.iter().any(|t| t.starts_with("🟢 online")),
             "active должен быть зелёным: {texts:?}"
@@ -793,7 +873,15 @@ mod tests {
                 last_handshake: Some(0),
             },
         ];
-        let texts = all_button_texts(&clients_list(Lang::Ru, &clients, &[], now, 0, 10));
+        let texts = all_button_texts(&clients_list(
+            Lang::Ru,
+            &clients,
+            &[],
+            now,
+            0,
+            10,
+            ClientFilter::All,
+        ));
         assert!(
             texts
                 .iter()
@@ -805,6 +893,73 @@ mod tests {
                 .iter()
                 .any(|t| t.contains("fresh") && t.contains("никогда")),
             "fresh (last_handshake=0) должен показывать «никогда»: {texts:?}"
+        );
+    }
+
+    #[test]
+    fn clients_list_has_filter_row_with_four_buttons() {
+        // Ряд фильтра: [Все] [🟢 Онлайн] [🔴 Оффлайн] [🟡 Никогда] —
+        // четыре callback `listfilter:*`.
+        let clients = vec![Client {
+            name: "a".into(),
+            ip: String::new(),
+            client_ipv6: String::new(),
+            status: String::new(),
+            status_code: "active".into(),
+            rx: 0,
+            tx: 0,
+            last_handshake: None,
+        }];
+        let data = all_callback_data(&clients_list(
+            Lang::Ru,
+            &clients,
+            &[],
+            0,
+            0,
+            10,
+            ClientFilter::All,
+        ));
+        assert!(data.contains(&"listfilter:all".to_string()));
+        assert!(data.contains(&"listfilter:online".to_string()));
+        assert!(data.contains(&"listfilter:offline".to_string()));
+        assert!(data.contains(&"listfilter:never".to_string()));
+    }
+
+    #[test]
+    fn clients_list_marks_active_filter_with_checkmark() {
+        // Активный фильтр помечается ✅-префиксом в подписи кнопки.
+        let clients = vec![Client {
+            name: "a".into(),
+            ip: String::new(),
+            client_ipv6: String::new(),
+            status: String::new(),
+            status_code: "active".into(),
+            rx: 0,
+            tx: 0,
+            last_handshake: None,
+        }];
+        let texts_online = all_button_texts(&clients_list(
+            Lang::Ru,
+            &clients,
+            &[],
+            0,
+            0,
+            10,
+            ClientFilter::Online,
+        ));
+        assert!(
+            texts_online
+                .iter()
+                .any(|t| t.contains("✅") && t.contains("Онлайн")),
+            "активный фильтр Online должен иметь ✅: {texts_online:?}"
+        );
+        // Все остальные фильтры — без ✅
+        assert!(
+            texts_online
+                .iter()
+                .filter(|t| t.contains("Оффлайн"))
+                .all(|t| !t.contains("✅")),
+            "неактивные фильтры не должны иметь ✅: {texts_online:?}"
         );
     }
 

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -423,6 +423,34 @@ pub fn clients_title(lang: Lang) -> String {
     }
     .to_string()
 }
+
+/// Заголовок списка клиентов с индикатором активного фильтра.
+/// `All` (или когда показаны все) → без пометки (как `clients_title`).
+/// Иначе → «👥 Клиенты — 🟢 онлайн (3 из 10)».
+pub fn clients_title_filtered(
+    lang: Lang,
+    filter: crate::vpn::model::ClientFilter,
+    shown: usize,
+    total: usize,
+) -> String {
+    if matches!(filter, crate::vpn::model::ClientFilter::All) || shown == total {
+        return clients_title(lang);
+    }
+    let mark = filter.mark();
+    let label = match (lang, filter) {
+        (Lang::Ru, crate::vpn::model::ClientFilter::Online) => "онлайн",
+        (Lang::En, crate::vpn::model::ClientFilter::Online) => "online",
+        (Lang::Ru, crate::vpn::model::ClientFilter::Offline) => "оффлайн",
+        (Lang::En, crate::vpn::model::ClientFilter::Offline) => "offline",
+        (Lang::Ru, crate::vpn::model::ClientFilter::Never) => "никогда",
+        (Lang::En, crate::vpn::model::ClientFilter::Never) => "never",
+        _ => "",
+    };
+    match lang {
+        Lang::Ru => format!("👥 <b>Клиенты</b> — {mark} {label} ({shown} из {total})"),
+        Lang::En => format!("👥 <b>Clients</b> — {mark} {label} ({shown} of {total})"),
+    }
+}
 pub fn not_found(lang: Lang) -> String {
     match lang {
         Lang::Ru => "Клиент не найден.",
@@ -1400,5 +1428,36 @@ mod tests {
             assert!(!qr_not_generated(l).is_empty());
             assert!(!link_unavailable(l).is_empty());
         }
+    }
+
+    #[test]
+    fn clients_title_all_has_no_filter_label() {
+        use crate::vpn::model::ClientFilter;
+        // All → как clients_title, без пометки фильтра.
+        let ru = clients_title_filtered(Lang::Ru, ClientFilter::All, 5, 10);
+        let en = clients_title_filtered(Lang::En, ClientFilter::All, 5, 10);
+        assert_eq!(ru, "👥 <b>Клиенты</b>:");
+        assert_eq!(en, "👥 <b>Clients</b>:");
+    }
+
+    #[test]
+    fn clients_title_filtered_shows_label_and_count() {
+        use crate::vpn::model::ClientFilter;
+        let ru = clients_title_filtered(Lang::Ru, ClientFilter::Online, 3, 10);
+        assert!(ru.contains("🟢"));
+        assert!(ru.contains("онлайн"));
+        assert!(ru.contains("(3 из 10)"));
+        let en = clients_title_filtered(Lang::En, ClientFilter::Never, 2, 8);
+        assert!(en.contains("🟡"));
+        assert!(en.contains("never"));
+        assert!(en.contains("(2 of 8)"));
+    }
+
+    #[test]
+    fn clients_title_filtered_shown_equals_total_drops_label() {
+        use crate::vpn::model::ClientFilter;
+        // Фильтр активен, но показаны все (напр. 3 из 3 онлайн) → без пометки.
+        let ru = clients_title_filtered(Lang::Ru, ClientFilter::Online, 3, 3);
+        assert_eq!(ru, "👥 <b>Клиенты</b>:");
     }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -5,6 +5,7 @@ use std::sync::Mutex;
 use serde::{Deserialize, Serialize};
 
 use crate::i18n::Lang;
+use crate::vpn::model::ClientFilter;
 
 fn default_true() -> bool {
     true
@@ -24,6 +25,9 @@ pub struct BotState {
     pub deliver_qr: bool,
     #[serde(default = "default_true")]
     pub deliver_link: bool,
+    /// Фильтр списка клиентов по статусу (персистентный, как name_slug/deliver_*).
+    #[serde(default)]
+    pub client_filter: ClientFilter,
 }
 
 impl Default for BotState {
@@ -35,6 +39,7 @@ impl Default for BotState {
             deliver_conf: true,
             deliver_qr: true,
             deliver_link: true,
+            client_filter: ClientFilter::default(),
         }
     }
 }
@@ -152,6 +157,18 @@ impl SettingsStore {
         drop(s);
         self.persist(&snapshot);
     }
+
+    pub fn client_filter(&self) -> ClientFilter {
+        self.state.lock().unwrap().client_filter
+    }
+
+    pub fn set_client_filter(&self, f: ClientFilter) {
+        let mut s = self.state.lock().unwrap();
+        s.client_filter = f;
+        let snapshot = s.clone();
+        drop(s);
+        self.persist(&snapshot);
+    }
 }
 
 #[cfg(test)]
@@ -264,5 +281,46 @@ mod tests {
         assert!(s.deliver_conf());
         assert!(s.deliver_qr());
         assert!(s.deliver_link());
+    }
+
+    #[test]
+    fn client_filter_default_is_all() {
+        let (_d, s) = store();
+        assert_eq!(s.client_filter(), ClientFilter::All);
+    }
+
+    #[test]
+    fn client_filter_set_and_get() {
+        let (_d, s) = store();
+        s.set_client_filter(ClientFilter::Online);
+        assert_eq!(s.client_filter(), ClientFilter::Online);
+        s.set_client_filter(ClientFilter::Never);
+        assert_eq!(s.client_filter(), ClientFilter::Never);
+    }
+
+    #[test]
+    fn client_filter_persists_across_reload() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.json");
+        {
+            let s = SettingsStore::load(path.clone());
+            s.set_client_filter(ClientFilter::Offline);
+        }
+        let s2 = SettingsStore::load(path);
+        assert_eq!(s2.client_filter(), ClientFilter::Offline);
+    }
+
+    #[test]
+    fn client_filter_default_all_when_missing_in_old_state() {
+        // Старый state.json без client_filter должен десериализоваться как All.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.json");
+        std::fs::write(
+            &path,
+            r#"{"psk_default":true,"name_slug":false,"langs":{}}"#,
+        )
+        .unwrap();
+        let s = SettingsStore::load(path);
+        assert_eq!(s.client_filter(), ClientFilter::All);
     }
 }

--- a/src/vpn/model.rs
+++ b/src/vpn/model.rs
@@ -1,4 +1,4 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::i18n::Lang;
 
@@ -45,6 +45,91 @@ pub fn status_mark_code(status_code: &str) -> &'static str {
         "no_handshake" | "no_data" => "🟡",
         _ => "🔴",
     }
+}
+
+/// Фильтр списка клиентов по цветовому статусу. Хранится персистентно в
+/// `BotState` (как `name_slug`/`deliver_*`), серилизуется snake_case.
+/// `as_str`/`from_str` — для callback_data кнопок (`listfilter:online`…).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ClientFilter {
+    #[default]
+    All,
+    Online,
+    Offline,
+    Never,
+}
+
+impl ClientFilter {
+    /// Строковое представление для callback_data и сериализации.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ClientFilter::All => "all",
+            ClientFilter::Online => "online",
+            ClientFilter::Offline => "offline",
+            ClientFilter::Never => "never",
+        }
+    }
+
+    /// Парсинг из callback_data. Unknown → None (вызывающий код → Action::Unknown).
+    /// Имя `parse_str`, а не `from_str`, чтобы не конфликтовать с
+    /// `std::str::FromStr::from_str` (clippy::should_implement_trait).
+    pub fn parse_str(s: &str) -> Option<ClientFilter> {
+        match s {
+            "all" => Some(ClientFilter::All),
+            "online" => Some(ClientFilter::Online),
+            "offline" => Some(ClientFilter::Offline),
+            "never" => Some(ClientFilter::Never),
+            _ => None,
+        }
+    }
+
+    /// Подходит ли клиент под этот фильтр (по `status_mark_code`).
+    pub fn matches(self, c: &Client) -> bool {
+        match self {
+            ClientFilter::All => true,
+            ClientFilter::Online => c.status_mark() == "🟢",
+            ClientFilter::Offline => c.status_mark() == "🔴",
+            ClientFilter::Never => c.status_mark() == "🟡",
+        }
+    }
+
+    /// Цветной эмодзи фильтра — для кнопок и заголовка списка.
+    pub fn mark(self) -> &'static str {
+        match self {
+            ClientFilter::All => "👥",
+            ClientFilter::Online => "🟢",
+            ClientFilter::Offline => "🔴",
+            ClientFilter::Never => "🟡",
+        }
+    }
+}
+
+/// Приоритет цвета для сортировки «онлайн вперёд»: 🟢(0) → 🔴(1) → 🟡(2).
+fn color_priority(mark: &str) -> u8 {
+    match mark {
+        "🟢" => 0,
+        "🔴" => 1,
+        _ => 2,
+    }
+}
+
+/// Фильтрует клиентов по `filter` и сортирует «онлайн вперёд» (🟢 → 🔴 → 🟡),
+/// внутри группы — по имени. Клонирует (handler передаёт owned Vec в clients_list).
+/// `All` пропускает всех, но сортировку применяет всегда — это режим по умолчанию
+/// из issue #28 («сначала онлайн, потом оффлайн»).
+pub fn apply_filter_and_sort(clients: &[Client], filter: ClientFilter) -> Vec<Client> {
+    let mut out: Vec<Client> = clients
+        .iter()
+        .filter(|c| filter.matches(c))
+        .cloned()
+        .collect();
+    out.sort_by(|a, b| {
+        color_priority(a.status_mark())
+            .cmp(&color_priority(b.status_mark()))
+            .then_with(|| a.name.cmp(&b.name))
+    });
+    out
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -531,6 +616,126 @@ mod tests {
             last_handshake: None,
         };
         assert_eq!(c.status_mark(), "🟡");
+    }
+
+    // --- ClientFilter: as_str/from_str roundtrip + mark --- //
+
+    #[test]
+    fn client_filter_str_roundtrip() {
+        for f in [
+            ClientFilter::All,
+            ClientFilter::Online,
+            ClientFilter::Offline,
+            ClientFilter::Never,
+        ] {
+            assert_eq!(ClientFilter::parse_str(f.as_str()), Some(f));
+        }
+        assert_eq!(ClientFilter::parse_str("garbage"), None);
+    }
+
+    #[test]
+    fn client_filter_default_is_all() {
+        assert_eq!(ClientFilter::default(), ClientFilter::All);
+    }
+
+    #[test]
+    fn client_filter_marks() {
+        assert_eq!(ClientFilter::All.mark(), "👥");
+        assert_eq!(ClientFilter::Online.mark(), "🟢");
+        assert_eq!(ClientFilter::Offline.mark(), "🔴");
+        assert_eq!(ClientFilter::Never.mark(), "🟡");
+    }
+
+    fn mk_client(name: &str, code: &str) -> Client {
+        Client {
+            name: name.into(),
+            ip: String::new(),
+            client_ipv6: String::new(),
+            status: String::new(),
+            status_code: code.into(),
+            rx: 0,
+            tx: 0,
+            last_handshake: None,
+        }
+    }
+
+    #[test]
+    fn client_filter_matches_by_status_color() {
+        let online = mk_client("a", "active");
+        let recent = mk_client("b", "recent");
+        let offline = mk_client("c", "inactive");
+        let key_err = mk_client("d", "key_error");
+        let never = mk_client("e", "no_handshake");
+        let nodata = mk_client("f", "no_data");
+
+        // All пропускает всех
+        for c in [&online, &recent, &offline, &key_err, &never, &nodata] {
+            assert!(ClientFilter::All.matches(c));
+        }
+        // Online — только 🟢
+        assert!(ClientFilter::Online.matches(&online));
+        assert!(ClientFilter::Online.matches(&recent));
+        assert!(!ClientFilter::Online.matches(&offline));
+        assert!(!ClientFilter::Online.matches(&never));
+        // Offline — только 🔴
+        assert!(ClientFilter::Offline.matches(&offline));
+        assert!(ClientFilter::Offline.matches(&key_err));
+        assert!(!ClientFilter::Offline.matches(&online));
+        assert!(!ClientFilter::Offline.matches(&never));
+        // Never — только 🟡
+        assert!(ClientFilter::Never.matches(&never));
+        assert!(ClientFilter::Never.matches(&nodata));
+        assert!(!ClientFilter::Never.matches(&online));
+        assert!(!ClientFilter::Never.matches(&offline));
+    }
+
+    #[test]
+    fn apply_filter_online_leaves_only_green() {
+        let clients = vec![
+            mk_client("a", "active"),
+            mk_client("b", "inactive"),
+            mk_client("c", "no_handshake"),
+            mk_client("d", "recent"),
+        ];
+        let out = apply_filter_and_sort(&clients, ClientFilter::Online);
+        let names: Vec<&str> = out.iter().map(|c| c.name.as_str()).collect();
+        assert_eq!(names, vec!["a", "d"]);
+    }
+
+    #[test]
+    fn apply_filter_sorts_online_first_then_offline_then_never() {
+        // Перемешанный порядок → 🟢(a,d) → 🔴(b) → 🟡(c)
+        let clients = vec![
+            mk_client("b", "inactive"),
+            mk_client("c", "no_handshake"),
+            mk_client("a", "active"),
+            mk_client("d", "recent"),
+        ];
+        let out = apply_filter_and_sort(&clients, ClientFilter::All);
+        let names: Vec<&str> = out.iter().map(|c| c.name.as_str()).collect();
+        assert_eq!(names, vec!["a", "d", "b", "c"]);
+    }
+
+    #[test]
+    fn apply_filter_sorts_by_name_within_color_group() {
+        // Два 🟢, два 🔴 — внутри группы по имени.
+        let clients = vec![
+            mk_client("zoe", "active"),
+            mk_client("amy", "active"),
+            mk_client("zack", "inactive"),
+            mk_client("abe", "inactive"),
+        ];
+        let out = apply_filter_and_sort(&clients, ClientFilter::All);
+        let names: Vec<&str> = out.iter().map(|c| c.name.as_str()).collect();
+        // 🟢: amy, zoe (по имени); 🔴: abe, zack (по имени)
+        assert_eq!(names, vec!["amy", "zoe", "abe", "zack"]);
+    }
+
+    #[test]
+    fn apply_filter_empty_when_no_match() {
+        let clients = vec![mk_client("a", "active")];
+        let out = apply_filter_and_sort(&clients, ClientFilter::Never);
+        assert!(out.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Что делает

Продолжение #21, пункт 4 («Дополнительные возможности для администратора»).

**Фильтр списка клиентов** по цветовому статусу — 4 варианта (маппинг 1:1 на `status_mark_code` из #27):

| Кнопка | Что показывает | status_code |
|--------|----------------|-------------|
| Все | без фильтра | — |
| 🟢 Онлайн | активные | `active` / `recent` |
| 🔴 Оффлайн | давно отключившиеся | `inactive` / `key_error` |
| 🟡 Никогда | никогда не подключались | `no_handshake` / `no_data` |

**Сортировка** всегда включена: онлайн вперёд (🟢 → 🔴 → 🟡), внутри группы — по имени. Соответствует «сначала онлайн, потом оффлайн» из issue.

**Выбранный фильтр персистентен** — сохраняется между сессиями (как `name_slug`/`deliver_*`) и отображается в заголовке списка: `👥 Клиенты — 🟢 онлайн (3 из 10)`.

## Технические детали

- **`ClientFilter`** (`model.rs`) — enum с `Serialize`/`Deserialize` (snake_case), `as_str`/`parse_str`/`matches`/`mark`. `apply_filter_and_sort()` делает filter + stable sort по `(color_priority, name)`.
- **Хранение** (`settings.rs`) — `#[serde(default)] client_filter` в `BotState`, переживает перезагрузку, обратная совместимость со старым `state.json`.
- **Ряд фильтра** (`menu.rs`) — под пагинацией, активный фильтр с ✅. Подписи локализованы локально (как `day_label`).
- **Wiring** (`handlers.rs`) — `render_clients_list()` инкапсулирует общую логику (stats → filter+sort → render) для `Action::List`/`Page`/`SetListFilter`. При смене фильтра — сброс на страницу 0 (содержимое сменилось).

## Дизайн-решения (из анализа)
- **4 фильтра** вместо бинарного онлайн/оффлайн — 🟡 «никогда» выделена отдельно (важно для аудита неактивных клиентов).
- **Персистентное хранение** вместо per-session — фильтр переживает переходы по страницам и возврат в список.
- **Сортировка без тумблера** — всегда включена (как просит issue «по умолчанию»), UI-переключатель избыточен.

## Проверка
- `cargo test`: 273 unit + 4 integration, всё зелёное
- `cargo fmt --check`: чисто
- `cargo clippy --all-targets -- -D warnings`: чисто

Closes #28.