### PR TITLE
feat(installer): каналы обновлений stable/rc/beta/alpha

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,6 +73,9 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
+          # тег с SemVer-суффиксом (v0.7.0-rc.1) — prerelease: /releases/latest
+          # его не видит, существующие установки получают только stable
+          prerelease: ${{ contains(github.ref_name, '-') }}
           body_path: ${{ steps.notes.outputs.found == 'true' && 'release-notes.md' || '' }}
           generate_release_notes: ${{ steps.notes.outputs.found != 'true' }}
           files: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,23 @@ Format — [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioning 
 
 ### 🇷🇺 Русский
 
-_Пусто — изменений после v0.6.0 пока нет._
+#### ✨ Добавлено
+
+- **Каналы обновлений**: `awgram-setup update --channel stable|rc|beta|alpha` —
+  установка предрелизных сборок на своём сервере. Канал запоминается;
+  prerelease-каналы видят и стабильные релизы. Теги с суффиксом
+  (например `v0.7.0-rc.1`) публикуются как GitHub prerelease и невидимы
+  для обычного `update` на существующих установках.
 
 ### 🇬🇧 English
 
-_Empty — no changes since v0.6.0 yet._
+#### ✨ Added
+
+- **Update channels**: `awgram-setup update --channel stable|rc|beta|alpha` —
+  install pre-release builds on your own server. The channel is sticky;
+  pre-release channels also see stable releases. Suffixed tags
+  (e.g. `v0.7.0-rc.1`) are published as GitHub prereleases and stay
+  invisible to plain `update` on existing installs.
 
 ## [0.6.0] — 2026-07-29
 

--- a/README.en.md
+++ b/README.en.md
@@ -85,6 +85,10 @@ history) — `export AWGRAM_TOKEN='TOKEN'` before the same command without
 
 Post-install management: `awgram-setup update | config | status | uninstall`.
 
+Pre-release builds: `awgram-setup update --channel rc` (channels
+`stable|rc|beta|alpha`, the choice is sticky; to return run
+`awgram-setup update --channel stable`).
+
 ## How it works
 
 `awgram` is a single static binary (Rust, `teloxide`, long polling, no

--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ curl -fsSL https://github.com/ekuraev/awgram/releases/latest/download/install.sh
 
 Управление после установки: `awgram-setup update | config | status | uninstall`.
 
+Предрелизные сборки: `awgram-setup update --channel rc` (каналы
+`stable|rc|beta|alpha`, выбор запоминается; вернуться —
+`awgram-setup update --channel stable`).
+
 ## Как это работает
 
 `awgram` — один статический бинарник (Rust, `teloxide`, long polling, без

--- a/install.sh
+++ b/install.sh
@@ -602,7 +602,10 @@ awgram-setup — установка и управление awgram (Telegram-б�
   --admins 1,2,3        Telegram ID администраторов через запятую
   --script-path PATH    путь к manage_amneziawg.sh (по умолчанию /root/awg/manage_amneziawg.sh)
   --clients-dir PATH    каталог client-конфигов (по умолчанию каталог manage-скрипта)
-  --version vX.Y.Z      установить конкретный релиз вместо последнего
+  --version vX.Y.Z      установить конкретный релиз вместо последнего (канал не меняет)
+  --channel stable|rc|beta|alpha
+                        канал обновлений (запоминается); prerelease-каналы видят
+                        и стабильные релизы; вернуться: update --channel stable
   --yes | -y            без вопросов (для автоматизации; недостающий параметр — ошибка)
   --purge               (uninstall) удалить также конфиг и состояние
 
@@ -613,6 +616,7 @@ awgram-setup — установка и управление awgram (Telegram-б�
   curl -fsSL https://github.com/ekuraev/awgram/releases/latest/download/install.sh | bash
   curl -fsSL ... | bash -s -- install --lang ru --mode hardened --token 'X' --admins 1 --yes
   awgram-setup config --admins 1,2
+  awgram-setup update --channel rc
 EOF
 }
 help_en() {
@@ -637,7 +641,10 @@ Flags (install; config accepts --token/--admins/--script-path):
   --admins 1,2,3        comma-separated Telegram admin IDs
   --script-path PATH    path to manage_amneziawg.sh (default /root/awg/manage_amneziawg.sh)
   --clients-dir PATH    client-config dir (default: the manage-script directory)
-  --version vX.Y.Z      install a specific release instead of the latest
+  --version vX.Y.Z      install a specific release instead of the latest (does not change the channel)
+  --channel stable|rc|beta|alpha
+                        update channel (sticky); pre-release channels also see
+                        stable releases; to return: update --channel stable
   --yes | -y            no questions (for automation; a missing parameter is an error)
   --purge               (uninstall) also remove config and state
 
@@ -648,6 +655,7 @@ Examples:
   curl -fsSL https://github.com/ekuraev/awgram/releases/latest/download/install.sh | bash
   curl -fsSL ... | bash -s -- install --lang en --mode hardened --token 'X' --admins 1 --yes
   awgram-setup config --admins 1,2
+  awgram-setup update --channel rc
 EOF
 }
 cmd_help() {

--- a/install.sh
+++ b/install.sh
@@ -19,7 +19,7 @@ SUDOERS_FILE="/etc/sudoers.d/awgram"
 SVC_USER="awgram"
 
 UI_LANG=""; MODE=""; TOKEN=""; ADMINS=""; MANAGE_SCRIPT=""; CLIENTS_DIR=""
-PIN_VERSION=""; ASSUME_YES=0; NO_SYSTEMD=0; BINARY_FILE=""; PURGE=0
+PIN_VERSION=""; ASSUME_YES=0; NO_SYSTEMD=0; BINARY_FILE=""; PURGE=0; CHANNEL=""
 COMMAND=""; HELP_TOPIC=""; PKG=""; ARCH=""; INSTALLED_VERSION=""; TTY_IN=""
 PREV_MODE=""  # режим из setup.conf до этого запуска — для миграции state при смене
 STATE_DIR="/var/lib/awgram"
@@ -152,6 +152,8 @@ MSG_RU[state_migrated]="Файл состояния перенесён: %s -> %s
 MSG_EN[state_migrated]="State file migrated: %s -> %s"
 MSG_RU[err_locked]="Другой запуск awgram-setup ещё не завершился (lock: %s)"
 MSG_EN[err_locked]="Another awgram-setup run is still in progress (lock: %s)"
+MSG_RU[err_bad_channel]="Недопустимое значение --channel: %s (stable|rc|beta|alpha)"
+MSG_EN[err_bad_channel]="Invalid --channel value: %s (stable|rc|beta|alpha)"
 
 msg() {
   local key="$1"; shift || true
@@ -283,6 +285,7 @@ load_setup_conf() {
   v="$(sed -n 's/^LANG=//p' "$SETUP_CONF" | head -1)";           [ -n "$UI_LANG" ] || UI_LANG="$v"
   v="$(sed -n 's/^MODE=//p' "$SETUP_CONF" | head -1)";           PREV_MODE="$v"; [ -n "$MODE" ] || MODE="$v"
   v="$(sed -n 's/^VERSION=//p' "$SETUP_CONF" | head -1)";        INSTALLED_VERSION="$v"
+  v="$(sed -n 's/^CHANNEL=//p' "$SETUP_CONF" | head -1)";        [ -n "$CHANNEL" ] || CHANNEL="$v"
   v="$(sed -n 's/^MANAGE_SCRIPT=//p' "$SETUP_CONF" | head -1)";  [ -n "$MANAGE_SCRIPT" ] || MANAGE_SCRIPT="$v"
   v="$(sed -n 's/^CLIENTS_DIR=//p' "$SETUP_CONF" | head -1)";    [ -n "$CLIENTS_DIR" ] || CLIENTS_DIR="$v"
 }
@@ -293,6 +296,7 @@ save_setup_conf() {
 LANG=$UI_LANG
 MODE=$MODE
 VERSION=$INSTALLED_VERSION
+CHANNEL=${CHANNEL:-stable}
 MANAGE_SCRIPT=$MANAGE_SCRIPT
 CLIENTS_DIR=$CLIENTS_DIR
 EOF
@@ -319,10 +323,40 @@ ensure_deps() {
 # общие опции curl: не виснуть на плохой сети, пару повторов на сбой
 CURL_BASE=(--connect-timeout 10 --retry 2)
 
-fetch_latest_tag() {
-  local tag
-  tag="$(curl -fsSL "${CURL_BASE[@]}" --max-time 30 "https://api.github.com/repos/$REPO/releases/latest" 2>/dev/null \
-        | grep -o '"tag_name": *"[^"]*"' | head -1 | cut -d'"' -f4)" || true
+tag_matches_channel() { # $1=тег, $2=канал; 0 = тег допустим для канала
+  # канал = минимальный уровень стабильности: rc видит stable+rc,
+  # beta — stable+rc+beta, alpha — всё; незнакомый суффикс — никому
+  local tag="$1" ch="$2"
+  case "$tag" in
+    *-rc.*)    case "$ch" in rc|beta|alpha) return 0 ;; esac ;;
+    *-beta.*)  case "$ch" in beta|alpha)    return 0 ;; esac ;;
+    *-alpha.*) case "$ch" in alpha)         return 0 ;; esac ;;
+    *-*)       ;;
+    *)         return 0 ;;
+  esac
+  return 1
+}
+
+pick_channel_tag() { # $1=канал; stdin=теги по строке (новые сверху); stdout=первый подходящий
+  local ch="$1" t
+  while IFS= read -r t; do
+    if tag_matches_channel "$t" "$ch"; then printf '%s\n' "$t"; return 0; fi
+  done
+  return 1
+}
+
+fetch_latest_tag() { # $1=канал (пусто → stable)
+  local ch="${1:-stable}" tag
+  if [ "$ch" = "stable" ]; then
+    # /releases/latest игнорирует prerelease — прежнее поведение без изменений
+    tag="$(curl -fsSL "${CURL_BASE[@]}" --max-time 30 "https://api.github.com/repos/$REPO/releases/latest" 2>/dev/null \
+          | grep -o '"tag_name": *"[^"]*"' | head -1 | cut -d'"' -f4)" || true
+  else
+    # список отсортирован по дате создания (новые сверху) — берём первый тег,
+    # проходящий фильтр канала; prerelease-поле API не нужно, фильтр по суффиксу
+    tag="$(curl -fsSL "${CURL_BASE[@]}" --max-time 30 "https://api.github.com/repos/$REPO/releases?per_page=30" 2>/dev/null \
+          | grep -o '"tag_name": *"[^"]*"' | cut -d'"' -f4 | pick_channel_tag "$ch")" || true
+  fi
   [ -n "$tag" ] || die err_latest "$REPO"
   printf '%s\n' "$tag"
 }
@@ -842,6 +876,8 @@ main() {
       --script-path) MANAGE_SCRIPT="${2:?--script-path}"; shift 2 ;;
       --clients-dir) CLIENTS_DIR="${2:?--clients-dir}"; shift 2 ;;
       --version)     PIN_VERSION="${2:?--version}"; shift 2 ;;
+      --channel)     CHANNEL="${2:?--channel}"; shift 2
+                     case "$CHANNEL" in stable|rc|beta|alpha) ;; *) die err_bad_channel "$CHANNEL" ;; esac ;;
       --repo)        REPO="${2:?--repo}"; shift 2 ;;
       --binary-file) BINARY_FILE="${2:?--binary-file}"; shift 2 ;;
       --yes|-y)      ASSUME_YES=1; shift ;;

--- a/install.sh
+++ b/install.sh
@@ -287,7 +287,8 @@ load_setup_conf() {
   v="$(sed -n 's/^LANG=//p' "$SETUP_CONF" | head -1)";           [ -n "$UI_LANG" ] || UI_LANG="$v"
   v="$(sed -n 's/^MODE=//p' "$SETUP_CONF" | head -1)";           PREV_MODE="$v"; [ -n "$MODE" ] || MODE="$v"
   v="$(sed -n 's/^VERSION=//p' "$SETUP_CONF" | head -1)";        INSTALLED_VERSION="$v"
-  v="$(sed -n 's/^CHANNEL=//p' "$SETUP_CONF" | head -1)";        [ -n "$CHANNEL" ] || CHANNEL="$v"
+  v="$(sed -n 's/^CHANNEL=//p' "$SETUP_CONF" | head -1)"
+  case "$v" in stable|rc|beta|alpha) [ -n "$CHANNEL" ] || CHANNEL="$v" ;; esac
   v="$(sed -n 's/^MANAGE_SCRIPT=//p' "$SETUP_CONF" | head -1)";  [ -n "$MANAGE_SCRIPT" ] || MANAGE_SCRIPT="$v"
   v="$(sed -n 's/^CLIENTS_DIR=//p' "$SETUP_CONF" | head -1)";    [ -n "$CLIENTS_DIR" ] || CLIENTS_DIR="$v"
 }
@@ -717,6 +718,7 @@ cmd_update() {
   elif [ -n "$BINARY_FILE" ]; then tag="local"
   else tag="$(fetch_latest_tag "${CHANNEL:-stable}")"; fi
   if [ "$tag" = "$INSTALLED_VERSION" ] && [ -z "$BINARY_FILE" ] && [ -z "$PIN_VERSION" ]; then
+    [ ! -f "$SETUP_CONF" ] || save_setup_conf
     info up_to_date "$tag"; return 0
   fi
   TMPD="$(mktemp -d)"

--- a/install.sh
+++ b/install.sh
@@ -154,6 +154,8 @@ MSG_RU[err_locked]="Другой запуск awgram-setup ещё не заве�
 MSG_EN[err_locked]="Another awgram-setup run is still in progress (lock: %s)"
 MSG_RU[err_bad_channel]="Недопустимое значение --channel: %s (stable|rc|beta|alpha)"
 MSG_EN[err_bad_channel]="Invalid --channel value: %s (stable|rc|beta|alpha)"
+MSG_RU[st_channel]="Канал обновлений: %s"
+MSG_EN[st_channel]="Update channel: %s"
 
 msg() {
   local key="$1"; shift || true
@@ -555,7 +557,7 @@ cmd_install() {
   local tag staged
   if [ -n "$PIN_VERSION" ]; then tag="$PIN_VERSION"
   elif [ -n "$BINARY_FILE" ]; then tag="local"
-  else tag="$(fetch_latest_tag)"; fi
+  else tag="$(fetch_latest_tag "${CHANNEL:-stable}")"; fi
   TMPD="$(mktemp -d)"
   staged="$(fetch_binary "$tag")"
   install_binary "$staged"
@@ -705,7 +707,7 @@ cmd_update() {
   local tag staged
   if [ -n "$PIN_VERSION" ]; then tag="$PIN_VERSION"
   elif [ -n "$BINARY_FILE" ]; then tag="local"
-  else tag="$(fetch_latest_tag)"; fi
+  else tag="$(fetch_latest_tag "${CHANNEL:-stable}")"; fi
   if [ "$tag" = "$INSTALLED_VERSION" ] && [ -z "$BINARY_FILE" ] && [ -z "$PIN_VERSION" ]; then
     info up_to_date "$tag"; return 0
   fi
@@ -832,11 +834,12 @@ cmd_status() {
   init_tty; load_setup_conf; choose_language
   if [ ! -x "$BIN_PATH" ]; then msg st_none >&2; return 0; fi
   local latest svc
-  latest="$(fetch_latest_tag 2>/dev/null)" || latest=""
+  latest="$(fetch_latest_tag "${CHANNEL:-stable}" 2>/dev/null)" || latest=""
   [ -n "$latest" ] || latest="$(msg unknown)"
   if is_systemd; then svc="$(systemctl is-active awgram 2>/dev/null || true)"; else svc="$(msg unknown)"; fi
   msg st_installed "${INSTALLED_VERSION:-$(msg unknown)}" "$latest" >&2
   msg st_service "${svc:-$(msg unknown)}" "${MODE:-$(msg unknown)}" >&2
+  msg st_channel "${CHANNEL:-stable}" >&2
   if [ -r "$CFG_FILE" ]; then
     show_current || true
   fi

--- a/scripts/test-install-inner.sh
+++ b/scripts/test-install-inner.sh
@@ -200,4 +200,52 @@ tags=$'v0.7.0-alpha.2\nv0.7.0-rc.1\nv0.6.0'
 [ "$(pick_channel_tag alpha  <<<"$tags")" = "v0.7.0-alpha.2" ] || fail "pick alpha"
 pick_channel_tag rc <<<"v0.1.0-nightly.1" && fail "pick must fail when nothing matches"
 
+# --- сценарий 8b: каналы end-to-end через фейковый curl (без сети) ---
+# после сценария 7 всё удалено — ставим заново локальным бинарником
+bash /repo/install.sh install --yes --lang en --mode root \
+  --token TESTTOKEN --admins 1 --binary-file /tmp/fakebin --no-systemd
+printf '#!/bin/sh\necho rc1\n' > /tmp/fakebin3; chmod +x /tmp/fakebin3
+sha256sum < /tmp/fakebin3 | cut -d' ' -f1 > /tmp/fakebin3.hash
+# фейковый GitHub: /releases/latest → v0.6.0 (stable), /releases → rc.1 сверху;
+# бинарники/чек-суммы/install.sh отдаются локально (тот же приём, что fake systemctl)
+cat > /usr/local/bin/curl <<'FAKE'
+#!/bin/bash
+out=""; url=""; prev=""
+for a in "$@"; do
+  [ "$prev" = "-o" ] && out="$a"
+  case "$a" in http*) url="$a" ;; esac
+  prev="$a"
+done
+emit() { if [ -n "$out" ]; then cat > "$out"; else cat; fi; }
+case "$url" in
+  *api.github.com*releases/latest*) printf '{"tag_name": "v0.6.0"}\n' | emit ;;
+  *api.github.com*per_page*) printf '[{"tag_name": "v0.7.0-rc.1"},{"tag_name": "v0.6.0"}]\n' | emit ;;
+  *.sha256) f="${url##*/}"; printf '%s  %s\n' "$(cat /tmp/fakebin3.hash)" "${f%.sha256}" | emit ;;
+  *awgram-linux-*) emit < /tmp/fakebin3 ;;
+  *install.sh) emit < /repo/install.sh ;;
+  *) exit 22 ;;
+esac
+FAKE
+chmod +x /usr/local/bin/curl
+# переход на rc-канал: резолвится v0.7.0-rc.1, канал персистится
+/usr/local/bin/awgram-setup update --channel rc --yes --no-systemd
+grep -q '^CHANNEL=rc$' /etc/awgram/setup.conf || fail "channel not persisted"
+grep -q '^VERSION=v0.7.0-rc.1$' /etc/awgram/setup.conf || fail "rc version not installed"
+[ "$(sha256sum < /usr/local/bin/awgram)" = "$(sha256sum < /tmp/fakebin3)" ] || fail "rc binary content"
+# обычный update следует сохранённому каналу (rc.1 уже стоит → up to date)
+upd_out="$(/usr/local/bin/awgram-setup update --yes --no-systemd 2>&1)"
+grep -q 'v0.7.0-rc.1' <<<"$upd_out" || fail "sticky channel must resolve rc tag"
+grep -q '^VERSION=v0.7.0-rc.1$' /etc/awgram/setup.conf || fail "sticky update must stay on rc"
+# status: показывает канал и последний релиз СВОЕГО канала
+status_out="$(/usr/local/bin/awgram-setup status --no-systemd 2>&1)"
+grep -qi 'channel: rc' <<<"$status_out" || fail "status lacks channel line"
+grep -q 'v0.7.0-rc.1' <<<"$status_out" || fail "status latest must be per-channel"
+# возврат на stable — осознанный даунгрейд до v0.6.0
+/usr/local/bin/awgram-setup update --channel stable --yes --no-systemd
+grep -q '^CHANNEL=stable$' /etc/awgram/setup.conf || fail "channel not reset to stable"
+grep -q '^VERSION=v0.6.0$' /etc/awgram/setup.conf || fail "stable downgrade not applied"
+rm -f /usr/local/bin/curl /tmp/fakebin3 /tmp/fakebin3.hash
+/usr/local/bin/awgram-setup uninstall --yes --purge --no-systemd
+[ ! -e /etc/awgram ] || fail "cleanup after scenario 8b"
+
 echo "OK: all scenarios passed"

--- a/scripts/test-install-inner.sh
+++ b/scripts/test-install-inner.sh
@@ -176,4 +176,28 @@ rm -f /usr/local/bin/systemctl /usr/local/bin/journalctl
 /usr/local/bin/awgram-setup uninstall --yes --purge --no-systemd
 [ ! -e /etc/awgram ] || fail "cleanup after scenario 7"
 
+# --- сценарий 8: юниты канального фильтра (без сети) ---
+# main "$@" — последняя строка install.sh; отрезаем её и сорсим только функции
+sed '$d' /repo/install.sh > /tmp/install-funcs.sh
+# shellcheck disable=SC1091
+source /tmp/install-funcs.sh
+tag_matches_channel v0.6.0 stable          || fail "stable tag must match stable"
+tag_matches_channel v0.6.0 rc              || fail "stable tag must match rc"
+tag_matches_channel v0.6.0 alpha           || fail "stable tag must match alpha"
+tag_matches_channel v0.7.0-rc.1 stable     && fail "rc tag must not match stable"
+tag_matches_channel v0.7.0-rc.1 rc         || fail "rc tag must match rc"
+tag_matches_channel v0.7.0-rc.1 beta       || fail "rc tag must match beta"
+tag_matches_channel v0.7.0-rc.1 alpha      || fail "rc tag must match alpha"
+tag_matches_channel v0.7.0-beta.2 rc       && fail "beta tag must not match rc"
+tag_matches_channel v0.7.0-beta.2 beta     || fail "beta tag must match beta"
+tag_matches_channel v0.7.0-alpha.1 beta    && fail "alpha tag must not match beta"
+tag_matches_channel v0.7.0-alpha.1 alpha   || fail "alpha tag must match alpha"
+tag_matches_channel v0.7.0-nightly.1 alpha && fail "unknown suffix must match no channel"
+tags=$'v0.7.0-alpha.2\nv0.7.0-rc.1\nv0.6.0'
+[ "$(pick_channel_tag stable <<<"$tags")" = "v0.6.0" ]         || fail "pick stable"
+[ "$(pick_channel_tag rc     <<<"$tags")" = "v0.7.0-rc.1" ]    || fail "pick rc"
+[ "$(pick_channel_tag beta   <<<"$tags")" = "v0.7.0-rc.1" ]    || fail "pick beta falls to rc tag"
+[ "$(pick_channel_tag alpha  <<<"$tags")" = "v0.7.0-alpha.2" ] || fail "pick alpha"
+pick_channel_tag rc <<<"v0.1.0-nightly.1" && fail "pick must fail when nothing matches"
+
 echo "OK: all scenarios passed"

--- a/scripts/test-install-inner.sh
+++ b/scripts/test-install-inner.sh
@@ -129,6 +129,7 @@ grep -q '^admin_ids     = \[3\]$' /etc/awgram/config.toml || fail "config change
 # захват в переменную, не пайп в grep -q — см. комментарий к сценарию 5 (SIGPIPE)
 help_out="$(bash /repo/install.sh help)"
 grep -q 'AWGRAM_TOKEN' <<<"$help_out" || fail "help lacks AWGRAM_TOKEN"
+grep -q -- '--channel' <<<"$help_out" || fail "help lacks --channel"
 
 # --- сценарий 5e: невалидный токен отклоняется ---
 if bash /repo/install.sh config --token 'bad token!' --yes --no-systemd >/dev/null 2>&1; then

--- a/scripts/test-install-inner.sh
+++ b/scripts/test-install-inner.sh
@@ -237,11 +237,23 @@ grep -q '^VERSION=v0.7.0-rc.1$' /etc/awgram/setup.conf || fail "rc version not i
 upd_out="$(/usr/local/bin/awgram-setup update --yes --no-systemd 2>&1)"
 grep -q 'v0.7.0-rc.1' <<<"$upd_out" || fail "sticky channel must resolve rc tag"
 grep -q '^VERSION=v0.7.0-rc.1$' /etc/awgram/setup.conf || fail "sticky update must stay on rc"
+# смена канала на up-to-date-пути: beta тоже резолвит уже установленный rc.1 —
+# канал обязан персистится, даже когда бинарник не меняется (регрессия к finding 1)
+/usr/local/bin/awgram-setup update --channel beta --yes --no-systemd
+grep -q '^CHANNEL=beta$' /etc/awgram/setup.conf || fail "channel must persist on up-to-date path"
+grep -q '^VERSION=v0.7.0-rc.1$' /etc/awgram/setup.conf || fail "version must stay unchanged on up-to-date path"
+# возвращаем канал на rc (тоже up-to-date-путь) перед проверкой status
+/usr/local/bin/awgram-setup update --channel rc --yes --no-systemd
+grep -q '^CHANNEL=rc$' /etc/awgram/setup.conf || fail "channel must persist back to rc on up-to-date path"
 # status: показывает канал и последний релиз СВОЕГО канала
 status_out="$(/usr/local/bin/awgram-setup status --no-systemd 2>&1)"
 grep -qi 'channel: rc' <<<"$status_out" || fail "status lacks channel line"
 grep -q 'v0.7.0-rc.1' <<<"$status_out" || fail "status latest must be per-channel"
-# возврат на stable — осознанный даунгрейд до v0.6.0
+# --version не должен трогать сохранённый канал (channel-neutrality)
+/usr/local/bin/awgram-setup update --version v0.6.0 --yes --no-systemd
+grep -q '^CHANNEL=rc$' /etc/awgram/setup.conf || fail "explicit --version must not change channel"
+grep -q '^VERSION=v0.6.0$' /etc/awgram/setup.conf || fail "explicit --version must install pinned version"
+# возврат на stable — канал резолвит уже установленную v0.6.0 (снова up-to-date-путь)
 /usr/local/bin/awgram-setup update --channel stable --yes --no-systemd
 grep -q '^CHANNEL=stable$' /etc/awgram/setup.conf || fail "channel not reset to stable"
 grep -q '^VERSION=v0.6.0$' /etc/awgram/setup.conf || fail "stable downgrade not applied"


### PR DESCRIPTION
## Что сделано / What's done

Каналы обновлений для `awgram-setup`: `update --channel stable|rc|beta|alpha` ставит предрелизные сборки; канал запоминается в `setup.conf`, возврат — `update --channel stable`. Теги с SemVer-суффиксом (`v0.7.0-rc.1`) публикуются как GitHub prerelease, поэтому `/releases/latest` (и все существующие установки без флага) их не видят — обратная совместимость полная. Канал = минимальный уровень стабильности: rc-канал видит и стабильные релизы. Плюс фикс из ревью: канал персистится и на up-to-date-пути `update`.

Update channels for `awgram-setup`: `update --channel stable|rc|beta|alpha` installs pre-release builds; the channel is sticky via `setup.conf`, return with `update --channel stable`. Suffixed SemVer tags (`v0.7.0-rc.1`) are published as GitHub prereleases, so `/releases/latest` (and all existing installs without the flag) never see them — fully backward compatible. A channel is a minimum stability level: the rc channel also sees stable releases. Includes a review fix: the channel persists on the up-to-date `update` path too.

## Как проверено / How it was tested

- [x] `./scripts/test-install.sh` — оба образа (ubuntu:24.04, almalinux:9), `ALL OK`; новые сценарии: юниты канального фильтра (8) и e2e с фейковым GitHub (8b: переход на rc, липкость, per-channel status, персистенция на up-to-date-пути, нейтральность `--version`, возврат на stable)
- [x] `shellcheck install.sh scripts/test-install-inner.sh` — чисто
- [x] `cargo test` / fmt / clippy — Rust-код не затронут, проверяет CI

## Связанные issues / Related issues

—
