### PR TITLE
fix(bot): жёлтый статус клиентов в списке (list_enriched)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,25 @@ Format — [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioning 
 
 ### 🇷🇺 Русский
 
-_Пусто — изменений после v0.7.0 пока нет._
+#### 🐛 Исправлено
+
+- **Цвет статуса клиентов в списке**: клиенты, никогда не подключавшиеся или
+  давно отключившиеся, снова корректно показываются как 🟡, а не 🔴. Экран
+  списка (#27) был переключён на `stats --json`, который не различает «никогда
+  не подключался» и «был, но давно» — обоим он ставит `inactive` (🔴). Теперь
+  `status_code` берётся из `list --json` (детальная классификация), а
+  `last_handshake`/трафик — из `stats --json`.
 
 ### 🇬🇧 English
 
-_Empty — no changes since v0.7.0 yet._
+#### 🐛 Fixed
+
+- **Client status color in the list**: clients that never connected or
+  disconnected long ago are correctly shown as 🟡 again, not 🔴. The list
+  screen (#27) was switched to `stats --json`, which does not distinguish
+  "never connected" from "was connected long ago" — both get `inactive` (🔴).
+  Now `status_code` is taken from `list --json` (detailed classification),
+  while `last_handshake`/traffic come from `stats --json`.
 
 ## [0.7.0] — 2026-07-29
 

--- a/src/bot/handlers.rs
+++ b/src/bot/handlers.rs
@@ -761,10 +761,11 @@ async fn finish_bulk(
     }
 }
 
-/// Рендерит экран списка клиентов: stats → filter+sort → expiries → title →
-/// clients_list. Общая логика для Action::List / Action::Page / Action::SetListFilter
-/// (различаются только страницей и тем, кто читает/устанавливает фильтр из настроек).
-/// Пустой список (до или после фильтра) → friendly-сообщение + главное меню.
+/// Рендерит экран списка клиентов: list_enriched → filter+sort → expiries →
+/// title → clients_list. Общая логика для Action::List / Action::Page /
+/// Action::SetListFilter (различаются только страницей и тем, кто читает/
+/// устанавливает фильтр из настроек). Пустой список (до или после фильтра) →
+/// friendly-сообщение + главное меню.
 async fn render_clients_list(
     bot: &Bot,
     chat: ChatId,
@@ -774,7 +775,11 @@ async fn render_clients_list(
     settings: &SettingsStore,
     page: usize,
 ) {
-    match vpn.stats().await {
+    // list_enriched = status_code из list (корректная трёхцветная классификация)
+    // + last_handshake/rx/tx из stats (метка времени для кнопки). Чистый stats
+    // (#27) терял жёлтый статус никогда не подключавшихся клиентов (inactive 🔴
+    // вместо no_handshake 🟡) — см. vpn::Vpn::list_enriched.
+    match vpn.list_enriched().await {
         Ok(all_clients) => {
             // Фильтр + сортировка «онлайн вперёд» (🟢 → 🔴 → 🟡, внутри — по имени).
             // apply_filter_and_sort возвращает owned Vec — clients_list берёт срез по странице.

--- a/src/vpn/mod.rs
+++ b/src/vpn/mod.rs
@@ -62,6 +62,39 @@ impl Vpn {
         model::parse_client_list(&out).map_err(|e| crate::error::Error::Parse(e.to_string()))
     }
 
+    /// Клиенты с детальным `status_code` (из `list`) + `last_handshake`/`rx`/`tx`
+    /// (из `stats`). Экрану списка нужны обе градации: `list` даёт корректную
+    /// трёхцветную классификацию (no_handshake/no_data/key_error), а `stats` —
+    /// только временную метку handshake для кнопки.
+    ///
+    /// Регрессия #27: переключение списка на `stats` ради `last_handshake`
+    /// потеряло жёлтый статус для клиентов, никогда не подключавшихся — `stats`
+    /// маркирует их `inactive` (🔴), а `list` — `no_handshake` (🟡). Здесь `list`
+    /// остаётся авторитетным источником `status_code`, а `stats` лишь обогащает
+    /// меткой времени и трафиком по имени.
+    ///
+    /// `stats` fail-open: при его отказе список показывается по `list` (status_code
+    /// корректен, handshake отсутствует) — лучше, чем полностью прятать список.
+    /// Отказ `list` пробрасывается как ошибка (показывать нечего).
+    pub async fn list_enriched(&self) -> Result<Vec<Client>> {
+        let mut base = self.list().await?;
+        match self.stats().await {
+            Ok(stats) => {
+                for c in &mut base {
+                    if let Some(s) = stats.iter().find(|s| s.name == c.name) {
+                        c.last_handshake = s.last_handshake;
+                        c.rx = s.rx;
+                        c.tx = s.tx;
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "list_enriched: stats недоступен, список без handshake");
+            }
+        }
+        Ok(base)
+    }
+
     /// Проверяет, существует ли клиент с таким именем (через `list --json`).
     /// Авторитетно: отражает реальное состояние WireGuard, а не только файлы на диске.
     pub async fn exists(&self, name: &str) -> Result<bool> {
@@ -691,6 +724,85 @@ mod tests {
     async fn exists_propagates_script_failure() {
         let (_d, vpn) = vpn_with_script("#!/bin/sh\nexit 1\n");
         assert!(vpn.exists("alice").await.is_err());
+    }
+
+    // --- list_enriched: статус из list + handshake/трафик из stats. Регрессия
+    // #27: экран списка переключили на stats, потеряв жёлтый статус для клиентов,
+    // никогда не подключавшихся (stats → inactive 🔴, list → no_handshake 🟡). ---
+
+    #[tokio::test]
+    #[serial] // гонка ETXTBSY: параллельный fork удерживает write-fd чужого fake-скрипта до execve
+    async fn list_enriched_never_connected_is_yellow_not_red() {
+        // list маркирует «никогда не подключался» как no_handshake (🟡),
+        // stats — как inactive (🔴). status_code обязан прийти из list.
+        let stub = r#"#!/bin/sh
+case "$1" in
+  list)  echo '[{"name":"alice","status_code":"no_handshake"}]' ;;
+  stats) echo '[{"name":"alice","status_code":"inactive","last_handshake":0,"rx":0,"tx":0}]' ;;
+  *) exit 1 ;;
+esac
+"#;
+        let (_d, vpn) = vpn_with_script(stub);
+        let clients = vpn.list_enriched().await.unwrap();
+        assert_eq!(clients.len(), 1);
+        // 🟡 (no_handshake из list), НЕ 🔴 (inactive из stats).
+        assert_eq!(clients[0].status_mark(), "🟡");
+    }
+
+    #[tokio::test]
+    #[serial] // гонка ETXTBSY: параллельный fork удерживает write-fd чужого fake-скрипта до execve
+    async fn list_enriched_active_keeps_green_and_takes_handshake_from_stats() {
+        // Активный клиент: status_code из list (🟢) + last_handshake/rx/tx из stats.
+        let now: i64 = 1_700_000_000;
+        let stub = format!(
+            r#"#!/bin/sh
+case "$1" in
+  list)  echo '[{{"name":"alice","status_code":"active"}}]' ;;
+  stats) echo '[{{"name":"alice","status_code":"active","last_handshake":{hs},"rx":100,"tx":200}}]' ;;
+  *) exit 1 ;;
+esac
+"#,
+            hs = now - 120,
+        );
+        let (_d, vpn) = vpn_with_script(&stub);
+        let clients = vpn.list_enriched().await.unwrap();
+        assert_eq!(clients[0].status_mark(), "🟢");
+        assert_eq!(clients[0].last_handshake, Some(now - 120));
+        assert_eq!(clients[0].rx, 100);
+        assert_eq!(clients[0].tx, 200);
+    }
+
+    #[tokio::test]
+    #[serial] // гонка ETXTBSY: параллельный fork удерживает write-fd чужого fake-скрипта до execve
+    async fn list_enriched_fail_open_when_stats_errors() {
+        // stats упал — список показывается по list (status_code корректен),
+        // handshake отсутствует. Лучше, чем прятать список целиком.
+        let stub = r#"#!/bin/sh
+case "$1" in
+  list)  echo '[{"name":"alice","status_code":"active"}]' ;;
+  stats) exit 1 ;;
+  *) exit 1 ;;
+esac
+"#;
+        let (_d, vpn) = vpn_with_script(stub);
+        let clients = vpn.list_enriched().await.unwrap();
+        assert_eq!(clients[0].status_mark(), "🟢");
+        assert_eq!(clients[0].last_handshake, None);
+    }
+
+    #[tokio::test]
+    #[serial] // гонка ETXTBSY: параллельный fork удерживает write-fd чужого fake-скрипта до execve
+    async fn list_enriched_propagates_list_error() {
+        // list упал — показывать нечего, ошибка пробрасывается.
+        let stub = r#"#!/bin/sh
+case "$1" in
+  list)  exit 1 ;;
+  stats) echo '[]' ;;
+  *) exit 1 ;;
+esac
+"#;
+        let (_d, vpn) = vpn_with_script(stub);
+        assert!(vpn.list_enriched().await.is_err());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Что не так

C #27 (v0.7.0) экран списка клиентов переключили с `list` на `stats --json` ради `last_handshake` в кнопках — и при этом потеряли корректную трёхцветную классификацию статуса.

`manage_amneziawg.sh` классифицирует клиентов по-разному в `list` и `stats`:

| ситуация | `list` | `stats` |
|---|---|---|
| handshake < 3 мин | `active` 🟢 | `active` 🟢 |
| < 24 ч | `recent` 🟢 | `recent` 🟢 |
| > 24 ч назад | **`no_handshake` 🟡** | **`inactive` 🔴** |
| никогда не подключался | **`no_handshake` 🟡** | **`inactive` 🔴** |

Переключившись на `stats`, #27 лишил пользователей жёлтого: клиенты, никогда не подключавшиеся, стали показываться 🔴 — ровно то, что описано в #31 (хотя там репортёр видит 🔴 даже для активного клиента, что этим фиксом **не** покрывается — см. ниже).

## Что меняю

Новый метод `Vpn::list_enriched()` — база клиентов из `list` (авторитетный `status_code` с детальной классификацией), обогащённая `last_handshake`/`rx`/`tx` из `stats` по имени. `stats` fail-open: при его отказе список показывается по `list` (status_code корректен, handshake отсутствует); отказ `list` пробрасывается.

`render_clients_list` переключён с `vpn.stats()` на `vpn.list_enriched()`.

## Проверка

- Новые тесты `list_enriched_*` (4 шт.) в `vpn/mod.rs` — ядро регрессии, fail-open, проброс ошибок.
- Полный набор: **277 passed, 0 failed**, clippy чист, fmt чист.

```
cargo test --lib        # 277 passed
cargo clippy --all-targets -- -D warnings   # ok
cargo fmt --check       # ok
```

## Границы фикса

Этот PR закрывает регрессию классификации (#27: «никогда не подключался» снова 🟡, не 🔴).

Он **не** объясняет случай из #31, где репортёр видит 🔴 для клиента со **свежим** handshake (83 с назад) — для такого `stats` обязан выдать `active`→🟢 (проверено воспроизведением апстрим-логики). Для той ветки нужны диагностические данные с больной машины; безопасные (без PSK/публичных IP) команды — в комментариях к issue.

Closes #31 (часть).