### PR TITLE
feat(installer)!: каналы обновлений сокращены до stable|rc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,25 @@ Format — [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioning 
 
 ### 🇷🇺 Русский
 
-_Пусто — изменений после v0.7.0 пока нет._
+#### ♻️ Изменено
+
+- **Каналы обновлений сокращены до `stable|rc`** — beta/alpha упразднены,
+  не успев использоваться: `--channel beta|alpha` теперь отклоняется с
+  ошибкой, а старое значение `CHANNEL=beta|alpha` в `setup.conf` молча
+  трактуется как `stable`. В README и `awgram-setup help` зафиксировано,
+  что каналы доступны начиная с v0.7.0, и добавлена инструкция обновления
+  для серверов со скриптом старше v0.7.0.
 
 ### 🇬🇧 English
 
-_Empty — no changes since v0.7.0 yet._
+#### ♻️ Changed
+
+- **Update channels narrowed to `stable|rc`** — beta/alpha removed before
+  ever being used: `--channel beta|alpha` is now rejected with an error,
+  and a legacy `CHANNEL=beta|alpha` value in `setup.conf` is silently
+  treated as `stable`. README and `awgram-setup help` now state that
+  channels are available since v0.7.0 and include upgrade instructions
+  for servers running a pre-v0.7.0 script.
 
 ## [0.7.0] — 2026-07-29
 

--- a/README.en.md
+++ b/README.en.md
@@ -85,9 +85,17 @@ history) — `export AWGRAM_TOKEN='TOKEN'` before the same command without
 
 Post-install management: `awgram-setup update | config | status | uninstall`.
 
-Pre-release builds: `awgram-setup update --channel rc` (channels
-`stable|rc|beta|alpha`, the choice is sticky; to return run
-`awgram-setup update --channel stable`).
+Pre-release builds — available since **v0.7.0**: `awgram-setup update
+--channel rc` (the choice is sticky, the rc channel also sees stable
+releases; to return run `awgram-setup update --channel stable`). If the
+server's `awgram-setup` is older than v0.7.0, it has no `--channel` flag
+yet — either run a plain `awgram-setup update` (it updates the script
+itself too), or install an rc right away with a one-liner from the release:
+
+```bash
+curl -fsSL https://github.com/ekuraev/awgram/releases/download/vX.Y.Z-rc.N/install.sh \
+  | bash -s -- update --channel rc
+```
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -84,9 +84,17 @@ curl -fsSL https://github.com/ekuraev/awgram/releases/latest/download/install.sh
 
 Управление после установки: `awgram-setup update | config | status | uninstall`.
 
-Предрелизные сборки: `awgram-setup update --channel rc` (каналы
-`stable|rc|beta|alpha`, выбор запоминается; вернуться —
-`awgram-setup update --channel stable`).
+Предрелизные сборки — доступны начиная с **v0.7.0**: `awgram-setup update
+--channel rc` (выбор запоминается, канал rc видит и стабильные релизы;
+вернуться — `awgram-setup update --channel stable`). Если на сервере
+`awgram-setup` старше v0.7.0, флага `--channel` у него ещё нет — либо
+выполните обычный `awgram-setup update` (он обновит и сам скрипт), либо
+поставьте rc сразу однострочником из нужного релиза:
+
+```bash
+curl -fsSL https://github.com/ekuraev/awgram/releases/download/vX.Y.Z-rc.N/install.sh \
+  | bash -s -- update --channel rc
+```
 
 ## Как это работает
 

--- a/install.sh
+++ b/install.sh
@@ -152,8 +152,8 @@ MSG_RU[state_migrated]="Файл состояния перенесён: %s -> %s
 MSG_EN[state_migrated]="State file migrated: %s -> %s"
 MSG_RU[err_locked]="Другой запуск awgram-setup ещё не завершился (lock: %s)"
 MSG_EN[err_locked]="Another awgram-setup run is still in progress (lock: %s)"
-MSG_RU[err_bad_channel]="Недопустимое значение --channel: %s (stable|rc|beta|alpha)"
-MSG_EN[err_bad_channel]="Invalid --channel value: %s (stable|rc|beta|alpha)"
+MSG_RU[err_bad_channel]="Недопустимое значение --channel: %s (stable|rc)"
+MSG_EN[err_bad_channel]="Invalid --channel value: %s (stable|rc)"
 MSG_RU[st_channel]="Канал обновлений: %s"
 MSG_EN[st_channel]="Update channel: %s"
 
@@ -288,7 +288,7 @@ load_setup_conf() {
   v="$(sed -n 's/^MODE=//p' "$SETUP_CONF" | head -1)";           PREV_MODE="$v"; [ -n "$MODE" ] || MODE="$v"
   v="$(sed -n 's/^VERSION=//p' "$SETUP_CONF" | head -1)";        INSTALLED_VERSION="$v"
   v="$(sed -n 's/^CHANNEL=//p' "$SETUP_CONF" | head -1)"
-  case "$v" in stable|rc|beta|alpha) [ -n "$CHANNEL" ] || CHANNEL="$v" ;; esac
+  case "$v" in stable|rc) [ -n "$CHANNEL" ] || CHANNEL="$v" ;; esac
   v="$(sed -n 's/^MANAGE_SCRIPT=//p' "$SETUP_CONF" | head -1)";  [ -n "$MANAGE_SCRIPT" ] || MANAGE_SCRIPT="$v"
   v="$(sed -n 's/^CLIENTS_DIR=//p' "$SETUP_CONF" | head -1)";    [ -n "$CLIENTS_DIR" ] || CLIENTS_DIR="$v"
 }
@@ -327,15 +327,13 @@ ensure_deps() {
 CURL_BASE=(--connect-timeout 10 --retry 2)
 
 tag_matches_channel() { # $1=тег, $2=канал; 0 = тег допустим для канала
-  # канал = минимальный уровень стабильности: rc видит stable+rc,
-  # beta — stable+rc+beta, alpha — всё; незнакомый суффикс — никому
+  # канал = минимальный уровень стабильности: rc видит stable+rc;
+  # любой другой суффикс (в т.ч. -beta./-alpha.) — никому
   local tag="$1" ch="$2"
   case "$tag" in
-    *-rc.*)    case "$ch" in rc|beta|alpha) return 0 ;; esac ;;
-    *-beta.*)  case "$ch" in beta|alpha)    return 0 ;; esac ;;
-    *-alpha.*) case "$ch" in alpha)         return 0 ;; esac ;;
-    *-*)       ;;
-    *)         return 0 ;;
+    *-rc.*) case "$ch" in rc) return 0 ;; esac ;;
+    *-*)    ;;
+    *)      return 0 ;;
   esac
   return 1
 }
@@ -604,9 +602,8 @@ awgram-setup — установка и управление awgram (Telegram-б�
   --script-path PATH    путь к manage_amneziawg.sh (по умолчанию /root/awg/manage_amneziawg.sh)
   --clients-dir PATH    каталог client-конфигов (по умолчанию каталог manage-скрипта)
   --version vX.Y.Z      установить конкретный релиз вместо последнего (канал не меняет)
-  --channel stable|rc|beta|alpha
-                        канал обновлений (запоминается); prerelease-каналы видят
-                        и стабильные релизы; вернуться: update --channel stable
+  --channel stable|rc   канал обновлений, доступен с v0.7.0 (запоминается); канал rc
+                        видит и стабильные релизы; вернуться: update --channel stable
   --yes | -y            без вопросов (для автоматизации; недостающий параметр — ошибка)
   --purge               (uninstall) удалить также конфиг и состояние
 
@@ -643,9 +640,8 @@ Flags (install; config accepts --token/--admins/--script-path):
   --script-path PATH    path to manage_amneziawg.sh (default /root/awg/manage_amneziawg.sh)
   --clients-dir PATH    client-config dir (default: the manage-script directory)
   --version vX.Y.Z      install a specific release instead of the latest (does not change the channel)
-  --channel stable|rc|beta|alpha
-                        update channel (sticky); pre-release channels also see
-                        stable releases; to return: update --channel stable
+  --channel stable|rc   update channel, available since v0.7.0 (sticky); the rc
+                        channel also sees stable releases; to return: update --channel stable
   --yes | -y            no questions (for automation; a missing parameter is an error)
   --purge               (uninstall) also remove config and state
 
@@ -890,7 +886,7 @@ main() {
       --clients-dir) CLIENTS_DIR="${2:?--clients-dir}"; shift 2 ;;
       --version)     PIN_VERSION="${2:?--version}"; shift 2 ;;
       --channel)     CHANNEL="${2:?--channel}"; shift 2
-                     case "$CHANNEL" in stable|rc|beta|alpha) ;; *) die err_bad_channel "$CHANNEL" ;; esac ;;
+                     case "$CHANNEL" in stable|rc) ;; *) die err_bad_channel "$CHANNEL" ;; esac ;;
       --repo)        REPO="${2:?--repo}"; shift 2 ;;
       --binary-file) BINARY_FILE="${2:?--binary-file}"; shift 2 ;;
       --yes|-y)      ASSUME_YES=1; shift ;;

--- a/scripts/test-install-inner.sh
+++ b/scripts/test-install-inner.sh
@@ -184,21 +184,14 @@ sed '$d' /repo/install.sh > /tmp/install-funcs.sh
 source /tmp/install-funcs.sh
 tag_matches_channel v0.6.0 stable          || fail "stable tag must match stable"
 tag_matches_channel v0.6.0 rc              || fail "stable tag must match rc"
-tag_matches_channel v0.6.0 alpha           || fail "stable tag must match alpha"
 tag_matches_channel v0.7.0-rc.1 stable     && fail "rc tag must not match stable"
 tag_matches_channel v0.7.0-rc.1 rc         || fail "rc tag must match rc"
-tag_matches_channel v0.7.0-rc.1 beta       || fail "rc tag must match beta"
-tag_matches_channel v0.7.0-rc.1 alpha      || fail "rc tag must match alpha"
 tag_matches_channel v0.7.0-beta.2 rc       && fail "beta tag must not match rc"
-tag_matches_channel v0.7.0-beta.2 beta     || fail "beta tag must match beta"
-tag_matches_channel v0.7.0-alpha.1 beta    && fail "alpha tag must not match beta"
-tag_matches_channel v0.7.0-alpha.1 alpha   || fail "alpha tag must match alpha"
-tag_matches_channel v0.7.0-nightly.1 alpha && fail "unknown suffix must match no channel"
-tags=$'v0.7.0-alpha.2\nv0.7.0-rc.1\nv0.6.0'
-[ "$(pick_channel_tag stable <<<"$tags")" = "v0.6.0" ]         || fail "pick stable"
-[ "$(pick_channel_tag rc     <<<"$tags")" = "v0.7.0-rc.1" ]    || fail "pick rc"
-[ "$(pick_channel_tag beta   <<<"$tags")" = "v0.7.0-rc.1" ]    || fail "pick beta falls to rc tag"
-[ "$(pick_channel_tag alpha  <<<"$tags")" = "v0.7.0-alpha.2" ] || fail "pick alpha"
+tag_matches_channel v0.7.0-alpha.1 rc      && fail "alpha tag must not match rc"
+tag_matches_channel v0.7.0-nightly.1 rc    && fail "unknown suffix must match no channel"
+tags=$'v0.7.0-beta.2\nv0.7.0-rc.1\nv0.6.0'
+[ "$(pick_channel_tag stable <<<"$tags")" = "v0.6.0" ]      || fail "pick stable"
+[ "$(pick_channel_tag rc     <<<"$tags")" = "v0.7.0-rc.1" ] || fail "pick rc skips beta tag"
 pick_channel_tag rc <<<"v0.1.0-nightly.1" && fail "pick must fail when nothing matches"
 
 # --- сценарий 8b: каналы end-to-end через фейковый curl (без сети) ---
@@ -237,14 +230,10 @@ grep -q '^VERSION=v0.7.0-rc.1$' /etc/awgram/setup.conf || fail "rc version not i
 upd_out="$(/usr/local/bin/awgram-setup update --yes --no-systemd 2>&1)"
 grep -q 'v0.7.0-rc.1' <<<"$upd_out" || fail "sticky channel must resolve rc tag"
 grep -q '^VERSION=v0.7.0-rc.1$' /etc/awgram/setup.conf || fail "sticky update must stay on rc"
-# смена канала на up-to-date-пути: beta тоже резолвит уже установленный rc.1 —
-# канал обязан персистится, даже когда бинарник не меняется (регрессия к finding 1)
-/usr/local/bin/awgram-setup update --channel beta --yes --no-systemd
-grep -q '^CHANNEL=beta$' /etc/awgram/setup.conf || fail "channel must persist on up-to-date path"
-grep -q '^VERSION=v0.7.0-rc.1$' /etc/awgram/setup.conf || fail "version must stay unchanged on up-to-date path"
-# возвращаем канал на rc (тоже up-to-date-путь) перед проверкой status
-/usr/local/bin/awgram-setup update --channel rc --yes --no-systemd
-grep -q '^CHANNEL=rc$' /etc/awgram/setup.conf || fail "channel must persist back to rc on up-to-date path"
+# неизвестный канал (в т.ч. упразднённые beta/alpha) отклоняется валидацией флага
+/usr/local/bin/awgram-setup update --channel beta --yes --no-systemd >/dev/null 2>&1 \
+  && fail "removed channel beta must be rejected"
+grep -q '^CHANNEL=rc$' /etc/awgram/setup.conf || fail "rejected channel must not be persisted"
 # status: показывает канал и последний релиз СВОЕГО канала
 status_out="$(/usr/local/bin/awgram-setup status --no-systemd 2>&1)"
 grep -qi 'channel: rc' <<<"$status_out" || fail "status lacks channel line"
@@ -253,10 +242,11 @@ grep -q 'v0.7.0-rc.1' <<<"$status_out" || fail "status latest must be per-channe
 /usr/local/bin/awgram-setup update --version v0.6.0 --yes --no-systemd
 grep -q '^CHANNEL=rc$' /etc/awgram/setup.conf || fail "explicit --version must not change channel"
 grep -q '^VERSION=v0.6.0$' /etc/awgram/setup.conf || fail "explicit --version must install pinned version"
-# возврат на stable — канал резолвит уже установленную v0.6.0 (снова up-to-date-путь)
+# возврат на stable: канал резолвит уже установленную v0.6.0 — up-to-date-путь,
+# канал обязан персистится, даже когда бинарник не меняется (регрессия к finding 1)
 /usr/local/bin/awgram-setup update --channel stable --yes --no-systemd
-grep -q '^CHANNEL=stable$' /etc/awgram/setup.conf || fail "channel not reset to stable"
-grep -q '^VERSION=v0.6.0$' /etc/awgram/setup.conf || fail "stable downgrade not applied"
+grep -q '^CHANNEL=stable$' /etc/awgram/setup.conf || fail "channel must persist on up-to-date path"
+grep -q '^VERSION=v0.6.0$' /etc/awgram/setup.conf || fail "version must stay unchanged on up-to-date path"
 rm -f /usr/local/bin/curl /tmp/fakebin3 /tmp/fakebin3.hash
 /usr/local/bin/awgram-setup uninstall --yes --purge --no-systemd
 [ ! -e /etc/awgram ] || fail "cleanup after scenario 8b"


### PR DESCRIPTION
## Что сделано / What's done

Каналы обновлений сокращены до `stable|rc` (beta/alpha упразднены, не успев использоваться): `--channel beta|alpha` отклоняется с ошибкой, legacy-значение `CHANNEL=beta|alpha` в `setup.conf` молча трактуется как `stable`. В README (ru/en) и `awgram-setup help` зафиксировано, что каналы доступны начиная с **v0.7.0**, и добавлена инструкция обновления для серверов со скриптом старше v0.7.0 (обычный `update` либо однострочник из rc-релиза).

Update channels narrowed to `stable|rc` (beta/alpha removed before ever being used): `--channel beta|alpha` is rejected, a legacy `CHANNEL=beta|alpha` in `setup.conf` is silently treated as `stable`. README (ru/en) and `awgram-setup help` now state channels are available since **v0.7.0** and include upgrade instructions for servers running a pre-v0.7.0 script.

## Как проверено / How it was tested

- [x] `./scripts/test-install.sh` — оба образа (ubuntu:24.04, almalinux:9), `ALL OK`; сценарий 8 переписан под два канала (beta/alpha-теги отклоняются), в 8b добавлена негативная проверка `--channel beta`
- [x] `shellcheck install.sh scripts/test-install-inner.sh` — чисто
- [x] `cargo test` / fmt / clippy — Rust-код не затронут, проверяет CI

## Связанные issues / Related issues

Доводка #30.
