### PR TITLE
fix(bot): tech debt групп — атомарная квота и гейт авторизации (#20)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,33 @@ Format — [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioning 
 
 ### 🇷🇺 Русский
 
-_Пусто — изменений после v0.8.0 пока нет._
+#### 🐛 Исправлено
+
+- **Гонка квоты группы**: при двух одновременных созданиях/переносах
+  клиентов в одну группу квота могла быть превышена — проверка и привязка
+  теперь атомарны; создание, проигравшее гонку, откатывается с сообщением
+  «квота исчерпана» ([#20](https://github.com/ekuraev/awgram/issues/20)).
+
+#### ♻️ Изменено
+
+- **Централизованная авторизация кнопок**: все callback-действия проходят
+  через единую таблицу доступа (владелец / групповой админ) — забытая
+  проверка в новом действии теперь невозможна by construction.
 
 ### 🇬🇧 English
 
-_Empty — no changes since v0.8.0 yet._
+#### 🐛 Fixed
+
+- **Group quota race**: two concurrent client creations/moves into the
+  same group could exceed the quota — the check and the binding are now
+  atomic; a creation that loses the race is rolled back with a
+  "quota reached" message ([#20](https://github.com/ekuraev/awgram/issues/20)).
+
+#### ♻️ Changed
+
+- **Centralized button authorization**: every callback action now passes
+  through a single access table (owner / group admin) — a forgotten check
+  in a new action is impossible by construction.
 
 ## [0.8.0] — 2026-07-31
 

--- a/src/bot/handlers.rs
+++ b/src/bot/handlers.rs
@@ -458,6 +458,12 @@ fn group_for_new_client(
     }
 }
 
+/// Нужен ли откат создания: не-recreate клиент не влез в квоту группы
+/// (проиграна гонка — ранняя проверка прошла, атомарная привязка нет).
+fn add_needs_quota_rollback(recreate: bool, outcome: &crate::store::QuotaAssign) -> bool {
+    !recreate && *outcome == crate::store::QuotaAssign::Full
+}
+
 /// Скоуп по роли: владельцу — сохранённый фильтр группы; групповому админу —
 /// текущая группа или None (нужен экран выбора группы).
 fn scope_for(role: &Role, settings: &Store, uid: i64) -> Option<ListScope> {
@@ -1095,7 +1101,55 @@ async fn finish_add(
             // создаёт заново, а перезатирает). Без безусловного вызова при
             // group=None «воскресшая» строка сохранила бы старую привязку —
             // группа-владелец получил бы доступ к новому чужому клиенту.
-            settings.assign_client_group(name, group, now_epoch());
+            //
+            // Привязка к группе. Для нового клиента с группой — атомарно с
+            // квотой: ранняя проверка выше могла пройти у двух конкурентов
+            // одновременно (vpn.add занимает секунды), решает только этот
+            // вызов. Recreate и клиент без группы — как раньше (квота не
+            // растёт / не применима); безусловность вызова при group=None
+            // сохраняется — см. комментарий про «воскресшую» строку выше.
+            let outcome = match group {
+                Some(gid) if !recreate => settings.try_assign_client_group(name, gid, now_epoch()),
+                _ => {
+                    settings.assign_client_group(name, group, now_epoch());
+                    crate::store::QuotaAssign::Assigned
+                }
+            };
+            if add_needs_quota_rollback(recreate, &outcome) {
+                // Компенсация: клиент создан, но в группу не влез — удаляем
+                // его и показываем «квота исчерпана». Артефакты не выдаём:
+                // клиент через мгновение перестанет существовать. В историю
+                // попадают ОБА события (add выше уже залогирован) — она
+                // отражает то, что реально произошло.
+                let gid = group.expect("rollback только при Some(group)");
+                if let Err(e) = vpn.remove(name).await {
+                    // Откат не удался: клиент существует, но без группы —
+                    // виден только владельцу, чинится вручную. Пользователю —
+                    // честная ошибка.
+                    tracing::error!(error = %e, client = name, "не удалось откатить клиента после гонки квоты");
+                    if let Some(m) = waiting {
+                        let _ = bot.delete_message(chat, m.id).await;
+                    }
+                    let _ = bot.send_message(chat, i18n::error_text(lang, &e)).await;
+                    return;
+                }
+                settings.log_event(
+                    now_epoch(),
+                    EventKind::ClientRemove,
+                    Some(name),
+                    Some(uid),
+                    Some("quota race rollback"),
+                );
+                if let Some(m) = waiting {
+                    let _ = bot.delete_message(chat, m.id).await;
+                }
+                let quota = settings.group(gid).and_then(|g| g.max_clients).unwrap_or(0);
+                let _ = bot
+                    .send_message(chat, i18n::quota_reached(lang, quota))
+                    .reply_markup(home)
+                    .await;
+                return;
+            }
             // Фильтр выдачи по тумблерам настроек (deliver_conf/qr/link): после
             // создания шлём только включённые артефакты. Ручная повторная выдача
             // через карточку клиента (SendConf/SendQr/SendLink/SendAll) фильтр
@@ -2909,6 +2963,18 @@ mod tests {
             group_for_new_client(&ga_only_a, &store, 43, false, "bob"),
             None
         );
+    }
+
+    #[test]
+    fn add_rollback_only_for_new_client_full() {
+        use crate::store::QuotaAssign;
+        // Откат (удалить созданного клиента) — только когда НОВЫЙ клиент
+        // проиграл гонку квоты. Recreate квоту не проверяет, Db — деградация
+        // без отката (клиент остаётся без группы, как раньше).
+        assert!(add_needs_quota_rollback(false, &QuotaAssign::Full));
+        assert!(!add_needs_quota_rollback(true, &QuotaAssign::Full));
+        assert!(!add_needs_quota_rollback(false, &QuotaAssign::Assigned));
+        assert!(!add_needs_quota_rollback(false, &QuotaAssign::Db));
     }
 
     #[test]

--- a/src/bot/handlers.rs
+++ b/src/bot/handlers.rs
@@ -437,6 +437,78 @@ fn client_in_scope(role: &Role, settings: &Store, name: &str) -> bool {
     role.can_see_client(settings.client_group(name))
 }
 
+/// Единая точка авторизации callback-Action. Исчерпывающий match БЕЗ
+/// wildcard — новый вариант Action не скомпилируется, пока автор явно не
+/// отнесёт его к классу доступа (раньше guard'ы были размазаны по веткам
+/// диспатча, и забытый guard в новом Action ничем не ловился).
+fn authorize(action: &Action, role: &Role, settings: &Store) -> bool {
+    use Action::*;
+    if *role == Role::Denied {
+        return false;
+    }
+    match action {
+        // Доступно всем аутентифицированным ролям.
+        Menu | List | Add | Stats | Page(_) | Expiry(_) | AddPsk(_) | Lang(_)
+        | SetListFilter(_) | Unknown => true,
+        // Экран/установка текущей группы: только GA, группа — только своя.
+        GroupSelectMenu => matches!(role, Role::GroupAdmin(_)),
+        GroupSelect(id) => matches!(role, Role::GroupAdmin(groups) if groups.contains(id)),
+        // Действия над конкретным клиентом — по скоупу роли.
+        ShowClient(name) | ClientHistory(name) | SendConf(name) | SendQr(name) | SendLink(name)
+        | SendAll(name) | AskDelete(name) | ConfirmDelete(name) | Recreate(name) | Regen(name) => {
+            client_in_scope(role, settings, name)
+        }
+        // Всё остальное — только владелец.
+        RegenAll
+        | RegenAllRun(_)
+        | AddBulk
+        | AddBulkRun(_)
+        | BulkExpiry(_)
+        | AddBulkPsk(_)
+        | Settings
+        | SetLang(_)
+        | SetPsk(_)
+        | SetSlug(_)
+        | SetConf(_)
+        | SetQr(_)
+        | SetLink(_)
+        | Modify(_)
+        | ModifyParam(_, _)
+        | Restart
+        | RestartRun
+        | RepairModule
+        | Backup
+        | BackupNew
+        | BackupList
+        | BackupCard(_)
+        | BackupDownload(_)
+        | Restore(_)
+        | RestoreYes(_)
+        | Check
+        | Diagnose
+        | Groups
+        | GroupCreate
+        | GroupCard(_)
+        | GroupRenameAsk(_)
+        | GroupQuotaAsk(_)
+        | GroupAdmins(_)
+        | GroupAdminRemove(_, _)
+        | GroupInvite(_)
+        | GroupInviteRevoke(_)
+        | GroupAdminById(_)
+        | GroupDeleteAsk(_)
+        | GroupDeleteDetach(_)
+        | GroupDeleteAllAsk(_)
+        | GroupDeleteAllYes(_)
+        | GroupRegenAsk(_)
+        | GroupRegenRun(_)
+        | MoveClientAsk(_)
+        | MoveClientTo(_, _)
+        | GroupScopeAsk
+        | GroupScopeSet(_) => role.is_owner(),
+    }
+}
+
 /// Группа для привязки клиента в finish_add. При recreate — существующая
 /// привязка: пересоздание не отвязывает клиента у владельца и не переносит
 /// его в текущую группу группового админа (скоуп на объект уже перепроверен
@@ -1465,7 +1537,13 @@ async fn callback_handler(
     let lang = settings.lang(uid);
 
     let data = q.data.clone().unwrap_or_default();
-    match parse_callback(&data) {
+    let action = parse_callback(&data);
+    // Единая авторизация. Отказ — молчаливый выход: callback уже отвечен в
+    // начале функции, прежние guard'ы вели себя так же.
+    if !authorize(&action, &role, &settings) {
+        return Ok(());
+    }
+    match action {
         Action::Menu => {
             dialogue.update(State::Idle).await?;
             match &role {
@@ -1503,19 +1581,19 @@ async fn callback_handler(
             }
         }
         Action::GroupSelect(id) => {
+            // Принадлежность группы роли уже проверена в authorize —
+            // здесь `groups` нужен только для рендера (groups.len()).
             if let Role::GroupAdmin(groups) = &role {
-                if groups.contains(&id) {
-                    settings.set_current_group(uid, id);
-                    let gname = settings.group(id).map(|g| g.name).unwrap_or_default();
-                    edit_or_send(
-                        &bot,
-                        chat,
-                        msg_id,
-                        i18n::ga_menu_title(lang, &gname),
-                        menu::ga_main_menu(lang, groups.len() > 1),
-                    )
-                    .await;
-                }
+                settings.set_current_group(uid, id);
+                let gname = settings.group(id).map(|g| g.name).unwrap_or_default();
+                edit_or_send(
+                    &bot,
+                    chat,
+                    msg_id,
+                    i18n::ga_menu_title(lang, &gname),
+                    menu::ga_main_menu(lang, groups.len() > 1),
+                )
+                .await;
             }
         }
         Action::List => {
@@ -1623,47 +1701,39 @@ async fn callback_handler(
                 }
             }
         }
-        Action::ShowClient(name) => {
-            if !client_in_scope(&role, &settings, &name) {
-                return Ok(());
-            }
-            match vpn.list_enriched().await {
-                Ok(clients) => match clients.iter().find(|c| c.name == name) {
-                    Some(c) => {
-                        let now = now_epoch();
-                        let expiry = vpn.client_expiry(&name);
-                        let traffic = settings.traffic_summary(Some(&name), now);
-                        let group_line = settings
-                            .client_group(&name)
-                            .and_then(|gid| settings.group(gid))
-                            .map(|g| i18n::group_label_line(lang, &g.name))
-                            .unwrap_or_default();
-                        edit_or_send(
-                            &bot,
-                            chat,
-                            msg_id,
-                            format!(
-                                "{}{}",
-                                format_client_card(lang, c, now, expiry, &traffic),
-                                group_line
-                            ),
-                            menu::client_card(lang, &name, role.is_owner()),
-                        )
-                        .await;
-                    }
-                    None => {
-                        bot.send_message(chat, i18n::not_found(lang)).await?;
-                    }
-                },
-                Err(e) => {
-                    bot.send_message(chat, i18n::error_text(lang, &e)).await?;
+        Action::ShowClient(name) => match vpn.list_enriched().await {
+            Ok(clients) => match clients.iter().find(|c| c.name == name) {
+                Some(c) => {
+                    let now = now_epoch();
+                    let expiry = vpn.client_expiry(&name);
+                    let traffic = settings.traffic_summary(Some(&name), now);
+                    let group_line = settings
+                        .client_group(&name)
+                        .and_then(|gid| settings.group(gid))
+                        .map(|g| i18n::group_label_line(lang, &g.name))
+                        .unwrap_or_default();
+                    edit_or_send(
+                        &bot,
+                        chat,
+                        msg_id,
+                        format!(
+                            "{}{}",
+                            format_client_card(lang, c, now, expiry, &traffic),
+                            group_line
+                        ),
+                        menu::client_card(lang, &name, role.is_owner()),
+                    )
+                    .await;
                 }
+                None => {
+                    bot.send_message(chat, i18n::not_found(lang)).await?;
+                }
+            },
+            Err(e) => {
+                bot.send_message(chat, i18n::error_text(lang, &e)).await?;
             }
-        }
+        },
         Action::ClientHistory(name) => {
-            if !client_in_scope(&role, &settings, &name) {
-                return Ok(());
-            }
             let now = now_epoch();
             let events = settings.client_events(&name, 10);
             edit_or_send(
@@ -1676,9 +1746,6 @@ async fn callback_handler(
             .await;
         }
         Action::SendConf(name) => {
-            if !client_in_scope(&role, &settings, &name) {
-                return Ok(());
-            }
             // 📄 Конфиг — только .conf, без QR/ссылки (фильтр выдачи не применяется:
             // это ручная повторная выдача конкретного артефакта).
             match vpn.existing_files(&name) {
@@ -1697,9 +1764,6 @@ async fn callback_handler(
             }
         }
         Action::SendQr(name) => {
-            if !client_in_scope(&role, &settings, &name) {
-                return Ok(());
-            }
             // 🖼 QR — опционален (qrencode может отсутствовать на сервере).
             match vpn.existing_files(&name) {
                 Ok(res) if std::path::Path::new(&res.qr_path).exists() => {
@@ -1717,9 +1781,6 @@ async fn callback_handler(
             }
         }
         Action::SendLink(name) => {
-            if !client_in_scope(&role, &settings, &name) {
-                return Ok(());
-            }
             // 🔗 Ссылка vpn:// — опциональна (qrencode генерирует её заодно с QR).
             match vpn.existing_files(&name) {
                 Ok(res) if !res.uri.is_empty() => {
@@ -1736,9 +1797,6 @@ async fn callback_handler(
             }
         }
         Action::SendAll(name) => {
-            if !client_in_scope(&role, &settings, &name) {
-                return Ok(());
-            }
             // 📦 Всё — безусловная выдача conf+QR+ссылка (фильтр настроек игнорируется:
             // пользователь явно запросил всё через карточку клиента).
             match vpn.existing_files(&name) {
@@ -1753,9 +1811,6 @@ async fn callback_handler(
             }
         }
         Action::AskDelete(name) => {
-            if !client_in_scope(&role, &settings, &name) {
-                return Ok(());
-            }
             edit_or_send(
                 &bot,
                 chat,
@@ -1765,34 +1820,26 @@ async fn callback_handler(
             )
             .await;
         }
-        Action::ConfirmDelete(name) => {
-            if !client_in_scope(&role, &settings, &name) {
-                return Ok(());
+        Action::ConfirmDelete(name) => match vpn.remove(&name).await {
+            Ok(()) => {
+                settings.log_event(
+                    now_epoch(),
+                    EventKind::ClientRemove,
+                    Some(&name),
+                    Some(uid),
+                    None,
+                );
+                bot.send_message(chat, i18n::deleted(lang, &name))
+                    .reply_markup(home_menu(&role, lang))
+                    .parse_mode(ParseMode::Html)
+                    .await?;
             }
-            match vpn.remove(&name).await {
-                Ok(()) => {
-                    settings.log_event(
-                        now_epoch(),
-                        EventKind::ClientRemove,
-                        Some(&name),
-                        Some(uid),
-                        None,
-                    );
-                    bot.send_message(chat, i18n::deleted(lang, &name))
-                        .reply_markup(home_menu(&role, lang))
-                        .parse_mode(ParseMode::Html)
-                        .await?;
-                }
-                Err(e) => {
-                    tracing::error!(error = %e, "remove провалился");
-                    bot.send_message(chat, i18n::error_text(lang, &e)).await?;
-                }
+            Err(e) => {
+                tracing::error!(error = %e, "remove провалился");
+                bot.send_message(chat, i18n::error_text(lang, &e)).await?;
             }
-        }
+        },
         Action::Recreate(name) => {
-            if !client_in_scope(&role, &settings, &name) {
-                return Ok(());
-            }
             bot.send_message(chat, i18n::ask_expiry(lang))
                 .reply_markup(menu::expiry_menu(lang))
                 .await?;
@@ -1804,9 +1851,6 @@ async fn callback_handler(
                 .await?;
         }
         Action::Regen(name) => {
-            if !client_in_scope(&role, &settings, &name) {
-                return Ok(());
-            }
             let waiting = bot.send_message(chat, i18n::regen_running(lang)).await.ok();
             match vpn.regen_client(&name).await {
                 Ok(res) => {
@@ -1831,9 +1875,6 @@ async fn callback_handler(
             }
         }
         Action::RegenAll => {
-            if !role.is_owner() {
-                return Ok(());
-            }
             edit_or_send(
                 &bot,
                 chat,
@@ -1844,9 +1885,6 @@ async fn callback_handler(
             .await;
         }
         Action::RegenAllRun(reset_routes) => {
-            if !role.is_owner() {
-                return Ok(());
-            }
             let waiting = bot
                 .send_message(chat, i18n::regen_all_running(lang))
                 .await
@@ -1992,9 +2030,6 @@ async fn callback_handler(
             dialogue.exit().await?;
         }
         Action::AddBulk => {
-            if !role.is_owner() {
-                return Ok(());
-            }
             // Шаг 1/4 массового диалога: запрос префикса (текстовый ввод, а не
             // кнопка). Валидация префикса — на следующем шаге (gen_bulk_names с
             // count=1 как smoke-проверка), тут только приглашение к вводу.
@@ -2002,9 +2037,6 @@ async fn callback_handler(
             dialogue.update(State::AwaitingBulkPrefix).await?;
         }
         Action::AddBulkRun(count) => {
-            if !role.is_owner() {
-                return Ok(());
-            }
             // callback_data — untrusted input (craftable). Клавиатура эмитит
             // только 1/3/5/10, но защищаемся от crafted bulk:N извне.
             if count == 0 || count > crate::vpn::validate::MAX_BULK as usize {
@@ -2035,9 +2067,6 @@ async fn callback_handler(
                 .await?;
         }
         Action::BulkExpiry(kind) => {
-            if !role.is_owner() {
-                return Ok(());
-            }
             // Шаг 3/4: срок выбран. «custom» → текстовый ввод срока,
             // иначе — переход к выбору PSK с уже готовым expires.
             let (prefix, count) = match dialogue.get().await?.unwrap_or_default() {
@@ -2076,9 +2105,6 @@ async fn callback_handler(
             }
         }
         Action::AddBulkPsk(psk) => {
-            if !role.is_owner() {
-                return Ok(());
-            }
             // Шаг 4/4: PSK выбран — финальный забег (превентивные проверки +
             // add_many + альбом). После finish_bulk диалог закрывается.
             let (prefix, count, expires) = match dialogue.get().await?.unwrap_or_default() {
@@ -2111,15 +2137,9 @@ async fn callback_handler(
             dialogue.exit().await?;
         }
         Action::Settings => {
-            if !role.is_owner() {
-                return Ok(());
-            }
             show_settings(&bot, chat, msg_id, lang, &settings).await;
         }
         Action::Modify(name) => {
-            if !role.is_owner() {
-                return Ok(());
-            }
             edit_or_send(
                 &bot,
                 chat,
@@ -2131,9 +2151,6 @@ async fn callback_handler(
             dialogue.update(State::AwaitingModifyParam { name }).await?;
         }
         Action::ModifyParam(name, param) => {
-            if !role.is_owner() {
-                return Ok(());
-            }
             bot.send_message(chat, i18n::ask_modify_param(lang, param))
                 .await?;
             dialogue
@@ -2141,9 +2158,6 @@ async fn callback_handler(
                 .await?;
         }
         Action::Restart => {
-            if !role.is_owner() {
-                return Ok(());
-            }
             edit_or_send(
                 &bot,
                 chat,
@@ -2154,9 +2168,6 @@ async fn callback_handler(
             .await;
         }
         Action::RestartRun => {
-            if !role.is_owner() {
-                return Ok(());
-            }
             let waiting = bot.send_message(chat, i18n::creating(lang)).await.ok();
             match vpn.restart().await {
                 Ok(out) => {
@@ -2179,9 +2190,6 @@ async fn callback_handler(
             }
         }
         Action::RepairModule => {
-            if !role.is_owner() {
-                return Ok(());
-            }
             let waiting = bot.send_message(chat, i18n::creating(lang)).await.ok();
             match vpn.repair_module().await {
                 Ok(out) => {
@@ -2218,9 +2226,6 @@ async fn callback_handler(
             .await;
         }
         Action::SetLang(code) => {
-            if !role.is_owner() {
-                return Ok(());
-            }
             if let Some(l) = i18n::parse_lang(&code) {
                 settings.set_lang(uid, l);
             }
@@ -2228,37 +2233,22 @@ async fn callback_handler(
             show_settings(&bot, chat, msg_id, lang, &settings).await;
         }
         Action::SetPsk(on) => {
-            if !role.is_owner() {
-                return Ok(());
-            }
             settings.set_psk_default(on);
             show_settings(&bot, chat, msg_id, lang, &settings).await;
         }
         Action::SetSlug(on) => {
-            if !role.is_owner() {
-                return Ok(());
-            }
             settings.set_name_slug(on);
             show_settings(&bot, chat, msg_id, lang, &settings).await;
         }
         Action::SetConf(on) => {
-            if !role.is_owner() {
-                return Ok(());
-            }
             settings.set_deliver_conf(on);
             show_settings(&bot, chat, msg_id, lang, &settings).await;
         }
         Action::SetQr(on) => {
-            if !role.is_owner() {
-                return Ok(());
-            }
             settings.set_deliver_qr(on);
             show_settings(&bot, chat, msg_id, lang, &settings).await;
         }
         Action::SetLink(on) => {
-            if !role.is_owner() {
-                return Ok(());
-            }
             settings.set_deliver_link(on);
             show_settings(&bot, chat, msg_id, lang, &settings).await;
         }
@@ -2296,9 +2286,6 @@ async fn callback_handler(
             .await;
         }
         Action::Backup => {
-            if !role.is_owner() {
-                return Ok(());
-            }
             edit_or_send(
                 &bot,
                 chat,
@@ -2309,9 +2296,6 @@ async fn callback_handler(
             .await;
         }
         Action::BackupNew => {
-            if !role.is_owner() {
-                return Ok(());
-            }
             let waiting = bot
                 .send_message(chat, i18n::backup_creating(lang))
                 .await
@@ -2334,122 +2318,99 @@ async fn callback_handler(
                 let _ = bot.delete_message(chat, m.id).await;
             }
         }
-        Action::BackupList => {
-            if !role.is_owner() {
-                return Ok(());
+        Action::BackupList => match vpn.list_backups() {
+            Ok(list) if list.is_empty() => {
+                edit_or_send(
+                    &bot,
+                    chat,
+                    msg_id,
+                    i18n::backups_empty(lang),
+                    menu::main_menu(lang),
+                )
+                .await;
             }
-            match vpn.list_backups() {
-                Ok(list) if list.is_empty() => {
+            Ok(list) => {
+                edit_or_send(
+                    &bot,
+                    chat,
+                    msg_id,
+                    i18n::backups_list_title(lang),
+                    menu::backups_list(lang, &list),
+                )
+                .await;
+            }
+            Err(e) => {
+                bot.send_message(chat, i18n::error_text(lang, &e)).await?;
+            }
+        },
+        Action::BackupCard(idx) => match vpn.list_backups() {
+            Ok(list) => match list.get(idx) {
+                Some(bf) => {
+                    let text = format!("<code>{}</code>", i18n::html_escape(&bf.name));
+                    edit_or_send(&bot, chat, msg_id, text, menu::backup_card(lang, idx)).await;
+                }
+                None => {
                     edit_or_send(
                         &bot,
                         chat,
                         msg_id,
-                        i18n::backups_empty(lang),
+                        i18n::backup_not_found(lang),
                         menu::main_menu(lang),
                     )
                     .await;
                 }
-                Ok(list) => {
+            },
+            Err(e) => {
+                bot.send_message(chat, i18n::error_text(lang, &e)).await?;
+            }
+        },
+        Action::BackupDownload(idx) => match vpn.list_backups() {
+            Ok(list) => match list.get(idx) {
+                Some(bf) => {
+                    if let Err(e) = bot.send_document(chat, InputFile::file(&bf.path)).await {
+                        tracing::error!(error = %e, "send_document провалился");
+                        let err = crate::error::Error::Telegram(e.to_string());
+                        bot.send_message(chat, i18n::error_text(lang, &err)).await?;
+                    }
+                }
+                None => {
+                    bot.send_message(chat, i18n::backup_not_found(lang))
+                        .reply_markup(menu::main_menu(lang))
+                        .await?;
+                }
+            },
+            Err(e) => {
+                bot.send_message(chat, i18n::error_text(lang, &e)).await?;
+            }
+        },
+        Action::Restore(idx) => match vpn.list_backups() {
+            Ok(list) => match list.get(idx) {
+                Some(bf) => {
                     edit_or_send(
                         &bot,
                         chat,
                         msg_id,
-                        i18n::backups_list_title(lang),
-                        menu::backups_list(lang, &list),
+                        i18n::confirm_restore(lang, &bf.name),
+                        menu::confirm_restore(lang, idx),
                     )
                     .await;
                 }
-                Err(e) => {
-                    bot.send_message(chat, i18n::error_text(lang, &e)).await?;
+                None => {
+                    edit_or_send(
+                        &bot,
+                        chat,
+                        msg_id,
+                        i18n::backup_not_found(lang),
+                        menu::main_menu(lang),
+                    )
+                    .await;
                 }
+            },
+            Err(e) => {
+                bot.send_message(chat, i18n::error_text(lang, &e)).await?;
             }
-        }
-        Action::BackupCard(idx) => {
-            if !role.is_owner() {
-                return Ok(());
-            }
-            match vpn.list_backups() {
-                Ok(list) => match list.get(idx) {
-                    Some(bf) => {
-                        let text = format!("<code>{}</code>", i18n::html_escape(&bf.name));
-                        edit_or_send(&bot, chat, msg_id, text, menu::backup_card(lang, idx)).await;
-                    }
-                    None => {
-                        edit_or_send(
-                            &bot,
-                            chat,
-                            msg_id,
-                            i18n::backup_not_found(lang),
-                            menu::main_menu(lang),
-                        )
-                        .await;
-                    }
-                },
-                Err(e) => {
-                    bot.send_message(chat, i18n::error_text(lang, &e)).await?;
-                }
-            }
-        }
-        Action::BackupDownload(idx) => {
-            if !role.is_owner() {
-                return Ok(());
-            }
-            match vpn.list_backups() {
-                Ok(list) => match list.get(idx) {
-                    Some(bf) => {
-                        if let Err(e) = bot.send_document(chat, InputFile::file(&bf.path)).await {
-                            tracing::error!(error = %e, "send_document провалился");
-                            let err = crate::error::Error::Telegram(e.to_string());
-                            bot.send_message(chat, i18n::error_text(lang, &err)).await?;
-                        }
-                    }
-                    None => {
-                        bot.send_message(chat, i18n::backup_not_found(lang))
-                            .reply_markup(menu::main_menu(lang))
-                            .await?;
-                    }
-                },
-                Err(e) => {
-                    bot.send_message(chat, i18n::error_text(lang, &e)).await?;
-                }
-            }
-        }
-        Action::Restore(idx) => {
-            if !role.is_owner() {
-                return Ok(());
-            }
-            match vpn.list_backups() {
-                Ok(list) => match list.get(idx) {
-                    Some(bf) => {
-                        edit_or_send(
-                            &bot,
-                            chat,
-                            msg_id,
-                            i18n::confirm_restore(lang, &bf.name),
-                            menu::confirm_restore(lang, idx),
-                        )
-                        .await;
-                    }
-                    None => {
-                        edit_or_send(
-                            &bot,
-                            chat,
-                            msg_id,
-                            i18n::backup_not_found(lang),
-                            menu::main_menu(lang),
-                        )
-                        .await;
-                    }
-                },
-                Err(e) => {
-                    bot.send_message(chat, i18n::error_text(lang, &e)).await?;
-                }
-            }
-        }
+        },
         Action::RestoreYes(idx) => {
-            if !role.is_owner() {
-                return Ok(());
-            }
             let waiting = bot.send_message(chat, i18n::restoring(lang)).await.ok();
             match vpn.restore(idx).await {
                 Ok(()) => {
@@ -2469,9 +2430,6 @@ async fn callback_handler(
             }
         }
         Action::Check => {
-            if !role.is_owner() {
-                return Ok(());
-            }
             let waiting = bot.send_message(chat, i18n::check_running(lang)).await.ok();
             match vpn.check().await {
                 Ok(report) => {
@@ -2491,9 +2449,6 @@ async fn callback_handler(
             }
         }
         Action::Diagnose => {
-            if !role.is_owner() {
-                return Ok(());
-            }
             let waiting = bot
                 .send_message(chat, i18n::diagnose_running(lang))
                 .await
@@ -2516,9 +2471,6 @@ async fn callback_handler(
             }
         }
         Action::Groups => {
-            if !role.is_owner() {
-                return Ok(());
-            }
             let groups: Vec<(crate::store::GroupRow, i64)> = settings
                 .list_groups()
                 .into_iter()
@@ -2535,36 +2487,21 @@ async fn callback_handler(
             edit_or_send(&bot, chat, msg_id, title, menu::groups_menu(lang, &groups)).await;
         }
         Action::GroupCreate => {
-            if !role.is_owner() {
-                return Ok(());
-            }
             bot.send_message(chat, i18n::ask_group_name(lang)).await?;
             dialogue.update(State::AwaitingGroupName).await?;
         }
         Action::GroupCard(id) => {
-            if !role.is_owner() {
-                return Ok(());
-            }
             show_group_card(&bot, chat, msg_id, lang, &settings, id).await;
         }
         Action::GroupRenameAsk(id) => {
-            if !role.is_owner() {
-                return Ok(());
-            }
             bot.send_message(chat, i18n::ask_group_name(lang)).await?;
             dialogue.update(State::AwaitingGroupRename { id }).await?;
         }
         Action::GroupQuotaAsk(id) => {
-            if !role.is_owner() {
-                return Ok(());
-            }
             bot.send_message(chat, i18n::ask_group_quota(lang)).await?;
             dialogue.update(State::AwaitingGroupQuota { id }).await?;
         }
         Action::GroupAdmins(id) => {
-            if !role.is_owner() {
-                return Ok(());
-            }
             let admins = settings.group_admin_ids(id);
             let name = settings.group(id).map(|g| g.name).unwrap_or_default();
             let title = if admins.is_empty() {
@@ -2582,9 +2519,6 @@ async fn callback_handler(
             .await;
         }
         Action::GroupAdminRemove(id, admin_uid) => {
-            if !role.is_owner() {
-                return Ok(());
-            }
             settings.remove_group_admin(id, admin_uid);
             settings.log_event(
                 now_epoch(),
@@ -2598,9 +2532,6 @@ async fn callback_handler(
             show_group_card(&bot, chat, msg_id, lang, &settings, id).await;
         }
         Action::GroupDeleteAsk(id) => {
-            if !role.is_owner() {
-                return Ok(());
-            }
             let name = settings.group(id).map(|g| g.name).unwrap_or_default();
             let count = settings.group_client_count(id);
             edit_or_send(
@@ -2613,9 +2544,6 @@ async fn callback_handler(
             .await;
         }
         Action::GroupDeleteDetach(id) => {
-            if !role.is_owner() {
-                return Ok(());
-            }
             let name = settings.group(id).map(|g| g.name).unwrap_or_default();
             settings.delete_group(id);
             settings.log_event(
@@ -2631,9 +2559,6 @@ async fn callback_handler(
                 .await?;
         }
         Action::GroupDeleteAllAsk(id) => {
-            if !role.is_owner() {
-                return Ok(());
-            }
             let name = settings.group(id).map(|g| g.name).unwrap_or_default();
             let count = settings.group_client_count(id);
             edit_or_send(
@@ -2646,9 +2571,6 @@ async fn callback_handler(
             .await;
         }
         Action::GroupDeleteAllYes(id) => {
-            if !role.is_owner() {
-                return Ok(());
-            }
             let name = settings.group(id).map(|g| g.name).unwrap_or_default();
             let clients = settings.group_client_names(id);
             let waiting = bot
@@ -2697,9 +2619,6 @@ async fn callback_handler(
             }
         }
         Action::GroupInvite(id) => {
-            if !role.is_owner() {
-                return Ok(());
-            }
             let first_admin_ever = !settings.has_any_group_admin();
             let Some(token) = settings.create_invite(id, uid, now_epoch()) else {
                 // Ошибка БД: ссылки нет — честная ошибка вместо «успеха»
@@ -2730,9 +2649,6 @@ async fn callback_handler(
             show_group_card(&bot, chat, msg_id, lang, &settings, id).await;
         }
         Action::GroupInviteRevoke(id) => {
-            if !role.is_owner() {
-                return Ok(());
-            }
             settings.revoke_invite(id);
             settings.log_event(
                 now_epoch(),
@@ -2745,16 +2661,10 @@ async fn callback_handler(
             show_group_card(&bot, chat, msg_id, lang, &settings, id).await;
         }
         Action::GroupAdminById(id) => {
-            if !role.is_owner() {
-                return Ok(());
-            }
             bot.send_message(chat, i18n::ask_admin_id(lang)).await?;
             dialogue.update(State::AwaitingGroupAdminId { id }).await?;
         }
         Action::MoveClientAsk(name) => {
-            if !role.is_owner() {
-                return Ok(());
-            }
             let groups = settings.list_groups();
             edit_or_send(
                 &bot,
@@ -2766,9 +2676,6 @@ async fn callback_handler(
             .await;
         }
         Action::MoveClientTo(target, name) => {
-            if !role.is_owner() {
-                return Ok(());
-            }
             // Целевая группа могла исчезнуть между показом меню (Task 13
             // ревью, Important) и кликом (другой владелец удалил её) — без
             // этой проверки assign_client_group молча пишет висячий
@@ -2807,9 +2714,6 @@ async fn callback_handler(
                 .await?;
         }
         Action::GroupRegenAsk(id) => {
-            if !role.is_owner() {
-                return Ok(());
-            }
             let name = settings.group(id).map(|g| g.name).unwrap_or_default();
             let count = settings.group_client_count(id);
             edit_or_send(
@@ -2822,9 +2726,6 @@ async fn callback_handler(
             .await;
         }
         Action::GroupRegenRun(id) => {
-            if !role.is_owner() {
-                return Ok(());
-            }
             let clients = settings.group_client_names(id);
             let waiting = bot
                 .send_message(chat, i18n::regen_all_running(lang))
@@ -2858,9 +2759,6 @@ async fn callback_handler(
                 .await?;
         }
         Action::GroupScopeAsk => {
-            if !role.is_owner() {
-                return Ok(());
-            }
             let groups = settings.list_groups();
             edit_or_send(
                 &bot,
@@ -2872,9 +2770,6 @@ async fn callback_handler(
             .await;
         }
         Action::GroupScopeSet(scope) => {
-            if !role.is_owner() {
-                return Ok(());
-            }
             settings.set_owner_scope(uid, scope);
             render_clients_list(
                 &bot,
@@ -3339,6 +3234,136 @@ mod tests {
                     "callback data {data:?} did not parse to a known Action"
                 );
             }
+        }
+    }
+
+    /// Табличный тест гейта авторизации: каждая строка — один Action и
+    /// ожидаемый доступ для owner/GA (снято с текущего поведения диспатча).
+    /// Denied проверяется отдельно на каждой строке — защита в глубину.
+    #[test]
+    fn authorize_table() {
+        use crate::store::ListScope;
+        let store = Store::open_in_memory();
+        let ga_group = store.create_group("a", 0).unwrap();
+        let foreign = store.create_group("b", 0).unwrap();
+        store.add_group_admin(ga_group, 42, 1, 0);
+        store.assign_client_group("mine", Some(ga_group), 10);
+        store.assign_client_group("theirs", Some(foreign), 10);
+        // "free" — клиент без группы (строки в БД нет — client_group → None).
+        let owner = Role::Owner;
+        let ga = Role::GroupAdmin(vec![ga_group]);
+        let denied = Role::Denied;
+
+        // (action, разрешено owner, разрешено ga)
+        let table: Vec<(Action, bool, bool)> = vec![
+            // Общие.
+            (Action::Menu, true, true),
+            (Action::List, true, true),
+            (Action::Add, true, true),
+            (Action::Stats, true, true),
+            (Action::Page(0), true, true),
+            (Action::Expiry("1d".into()), true, true),
+            (Action::AddPsk(true), true, true),
+            (Action::Lang("ru".into()), true, true),
+            (
+                Action::SetListFilter(crate::vpn::model::ClientFilter::All),
+                true,
+                true,
+            ),
+            (Action::Unknown, true, true),
+            // Выбор группы: только GA, и только своя.
+            (Action::GroupSelectMenu, false, true),
+            (Action::GroupSelect(ga_group), false, true),
+            (Action::GroupSelect(foreign), false, false),
+            // Клиентские: владелец — все, GA — только свой скоуп.
+            (Action::ShowClient("mine".into()), true, true),
+            (Action::ShowClient("theirs".into()), true, false),
+            (Action::ShowClient("free".into()), true, false),
+            (Action::ClientHistory("mine".into()), true, true),
+            (Action::ClientHistory("theirs".into()), true, false),
+            (Action::SendConf("mine".into()), true, true),
+            (Action::SendConf("theirs".into()), true, false),
+            (Action::SendQr("mine".into()), true, true),
+            (Action::SendQr("theirs".into()), true, false),
+            (Action::SendLink("mine".into()), true, true),
+            (Action::SendLink("theirs".into()), true, false),
+            (Action::SendAll("mine".into()), true, true),
+            (Action::SendAll("theirs".into()), true, false),
+            (Action::AskDelete("mine".into()), true, true),
+            (Action::AskDelete("theirs".into()), true, false),
+            (Action::ConfirmDelete("mine".into()), true, true),
+            (Action::ConfirmDelete("theirs".into()), true, false),
+            (Action::Recreate("mine".into()), true, true),
+            (Action::Recreate("theirs".into()), true, false),
+            (Action::Regen("mine".into()), true, true),
+            (Action::Regen("theirs".into()), true, false),
+            // Owner-only.
+            (Action::RegenAll, true, false),
+            (Action::RegenAllRun(false), true, false),
+            (Action::AddBulk, true, false),
+            (Action::AddBulkRun(3), true, false),
+            (Action::BulkExpiry("1d".into()), true, false),
+            (Action::AddBulkPsk(true), true, false),
+            (Action::Settings, true, false),
+            (Action::SetLang("en".into()), true, false),
+            (Action::SetPsk(true), true, false),
+            (Action::SetSlug(true), true, false),
+            (Action::SetConf(true), true, false),
+            (Action::SetQr(true), true, false),
+            (Action::SetLink(true), true, false),
+            (Action::Modify("mine".into()), true, false),
+            (
+                Action::ModifyParam("mine".into(), crate::vpn::validate::ModifyParam::Dns),
+                true,
+                false,
+            ),
+            (Action::Restart, true, false),
+            (Action::RestartRun, true, false),
+            (Action::RepairModule, true, false),
+            (Action::Backup, true, false),
+            (Action::BackupNew, true, false),
+            (Action::BackupList, true, false),
+            (Action::BackupCard(0), true, false),
+            (Action::BackupDownload(0), true, false),
+            (Action::Restore(0), true, false),
+            (Action::RestoreYes(0), true, false),
+            (Action::Check, true, false),
+            (Action::Diagnose, true, false),
+            (Action::Groups, true, false),
+            (Action::GroupCreate, true, false),
+            (Action::GroupCard(ga_group), true, false),
+            (Action::GroupRenameAsk(ga_group), true, false),
+            (Action::GroupQuotaAsk(ga_group), true, false),
+            (Action::GroupAdmins(ga_group), true, false),
+            (Action::GroupAdminRemove(ga_group, 42), true, false),
+            (Action::GroupInvite(ga_group), true, false),
+            (Action::GroupInviteRevoke(ga_group), true, false),
+            (Action::GroupAdminById(ga_group), true, false),
+            (Action::GroupDeleteAsk(ga_group), true, false),
+            (Action::GroupDeleteDetach(ga_group), true, false),
+            (Action::GroupDeleteAllAsk(ga_group), true, false),
+            (Action::GroupDeleteAllYes(ga_group), true, false),
+            (Action::GroupRegenAsk(ga_group), true, false),
+            (Action::GroupRegenRun(ga_group), true, false),
+            (Action::MoveClientAsk("mine".into()), true, false),
+            (
+                Action::MoveClientTo(Some(ga_group), "mine".into()),
+                true,
+                false,
+            ),
+            (Action::GroupScopeAsk, true, false),
+            (Action::GroupScopeSet(ListScope::All), true, false),
+        ];
+        for (action, owner_ok, ga_ok) in &table {
+            assert_eq!(
+                authorize(action, &owner, &store),
+                *owner_ok,
+                "owner: {action:?}"
+            );
+            assert_eq!(authorize(action, &ga, &store), *ga_ok, "ga: {action:?}");
+            // Denied не проходит НИЧЕГО — защита в глубину (обычно отсекается
+            // раньше, на входе в handle_callback).
+            assert!(!authorize(action, &denied, &store), "denied: {action:?}");
         }
     }
 }

--- a/src/bot/handlers.rs
+++ b/src/bot/handlers.rs
@@ -2725,22 +2725,28 @@ async fn callback_handler(
                     bot.send_message(chat, i18n::not_found(lang)).await?;
                     return Ok(());
                 };
-                // Квота действует и на перенос: полная группа не принимает
-                // клиентов (владелец сначала поднимает лимит). Перенос внутри
-                // той же группы — no-op, счётчик не растёт, не блокируем.
-                if settings.client_group(&name) != Some(id)
-                    && settings.group_remaining(id).is_some_and(|r| r < 1)
-                {
-                    let quota = g.max_clients.unwrap_or(0);
-                    bot.send_message(chat, i18n::quota_reached(lang, quota))
-                        .await?;
-                    return Ok(());
+                // Квота действует и на перенос: полная группа не принимает клиентов
+                // (владелец сначала поднимает лимит). Проверка и привязка — атомарно
+                // в store (TOCTOU-фикс); no-op переноса в свою же группу разрешён там же.
+                match settings.try_assign_client_group(&name, id, now_epoch()) {
+                    crate::store::QuotaAssign::Assigned => {}
+                    crate::store::QuotaAssign::Full => {
+                        let quota = g.max_clients.unwrap_or(0);
+                        bot.send_message(chat, i18n::quota_reached(lang, quota))
+                            .await?;
+                        return Ok(());
+                    }
+                    crate::store::QuotaAssign::Db => {
+                        let err = crate::error::Error::Telegram("db".into());
+                        bot.send_message(chat, i18n::error_text(lang, &err)).await?;
+                        return Ok(());
+                    }
                 }
                 Some(g.name)
             } else {
+                settings.assign_client_group(&name, None, now_epoch());
                 None
             };
-            settings.assign_client_group(&name, target, now_epoch());
             bot.send_message(chat, i18n::client_moved(lang, &name, gname.as_deref()))
                 .parse_mode(ParseMode::Html)
                 .reply_markup(menu::main_menu(lang))

--- a/src/bot/handlers.rs
+++ b/src/bot/handlers.rs
@@ -3237,6 +3237,165 @@ mod tests {
         }
     }
 
+    /// По одному образцу каждого варианта Action — база для проверки полноты
+    /// таблицы `authorize_table` ниже. Vec (в отличие от match в `authorize`)
+    /// сам по себе не заставит компилятор напомнить про новый вариант,
+    /// поэтому здесь есть отдельная компайл-страховка (см. ниже).
+    fn coverage_samples() -> Vec<Action> {
+        use Action::*;
+        let samples = vec![
+            Menu,
+            List,
+            Add,
+            Stats,
+            Page(0),
+            ShowClient("s".into()),
+            ClientHistory("s".into()),
+            SendConf("s".into()),
+            AskDelete("s".into()),
+            ConfirmDelete("s".into()),
+            Recreate("s".into()),
+            Regen("s".into()),
+            RegenAll,
+            RegenAllRun(false),
+            Expiry("none".into()),
+            Lang("ru".into()),
+            Settings,
+            SetLang("ru".into()),
+            SetPsk(false),
+            SetSlug(false),
+            AddPsk(false),
+            Backup,
+            BackupNew,
+            BackupList,
+            BackupCard(0),
+            BackupDownload(0),
+            Restore(0),
+            RestoreYes(0),
+            Check,
+            Diagnose,
+            Modify("s".into()),
+            ModifyParam("s".into(), crate::vpn::validate::ModifyParam::Dns),
+            Restart,
+            RestartRun,
+            RepairModule,
+            AddBulk,
+            AddBulkRun(1),
+            BulkExpiry("none".into()),
+            AddBulkPsk(false),
+            SendQr("s".into()),
+            SendLink("s".into()),
+            SendAll("s".into()),
+            SetConf(false),
+            SetQr(false),
+            SetLink(false),
+            SetListFilter(crate::vpn::model::ClientFilter::All),
+            Groups,
+            GroupCreate,
+            GroupCard(0),
+            GroupRenameAsk(0),
+            GroupQuotaAsk(0),
+            GroupAdmins(0),
+            GroupAdminRemove(0, 0),
+            GroupInvite(0),
+            GroupInviteRevoke(0),
+            GroupAdminById(0),
+            GroupDeleteAsk(0),
+            GroupDeleteDetach(0),
+            GroupDeleteAllAsk(0),
+            GroupDeleteAllYes(0),
+            GroupRegenAsk(0),
+            GroupRegenRun(0),
+            GroupSelect(0),
+            GroupSelectMenu,
+            MoveClientAsk("s".into()),
+            MoveClientTo(None, "s".into()),
+            GroupScopeAsk,
+            GroupScopeSet(crate::store::ListScope::All),
+            Unknown,
+        ];
+
+        // Компайл-страховка: исчерпывающий match без wildcard по каждому
+        // образцу. Добавили вариант в Action — этот match перестал
+        // собираться, пока сюда не добавлен образец нового варианта (а
+        // значит, и напоминание дописать для него строку в authorize_table).
+        for sample in &samples {
+            match sample {
+                Menu => {}
+                List => {}
+                Add => {}
+                Stats => {}
+                Page(_) => {}
+                ShowClient(_) => {}
+                ClientHistory(_) => {}
+                SendConf(_) => {}
+                AskDelete(_) => {}
+                ConfirmDelete(_) => {}
+                Recreate(_) => {}
+                Regen(_) => {}
+                RegenAll => {}
+                RegenAllRun(_) => {}
+                Expiry(_) => {}
+                Lang(_) => {}
+                Settings => {}
+                SetLang(_) => {}
+                SetPsk(_) => {}
+                SetSlug(_) => {}
+                AddPsk(_) => {}
+                Backup => {}
+                BackupNew => {}
+                BackupList => {}
+                BackupCard(_) => {}
+                BackupDownload(_) => {}
+                Restore(_) => {}
+                RestoreYes(_) => {}
+                Check => {}
+                Diagnose => {}
+                Modify(_) => {}
+                ModifyParam(_, _) => {}
+                Restart => {}
+                RestartRun => {}
+                RepairModule => {}
+                AddBulk => {}
+                AddBulkRun(_) => {}
+                BulkExpiry(_) => {}
+                AddBulkPsk(_) => {}
+                SendQr(_) => {}
+                SendLink(_) => {}
+                SendAll(_) => {}
+                SetConf(_) => {}
+                SetQr(_) => {}
+                SetLink(_) => {}
+                SetListFilter(_) => {}
+                Groups => {}
+                GroupCreate => {}
+                GroupCard(_) => {}
+                GroupRenameAsk(_) => {}
+                GroupQuotaAsk(_) => {}
+                GroupAdmins(_) => {}
+                GroupAdminRemove(_, _) => {}
+                GroupInvite(_) => {}
+                GroupInviteRevoke(_) => {}
+                GroupAdminById(_) => {}
+                GroupDeleteAsk(_) => {}
+                GroupDeleteDetach(_) => {}
+                GroupDeleteAllAsk(_) => {}
+                GroupDeleteAllYes(_) => {}
+                GroupRegenAsk(_) => {}
+                GroupRegenRun(_) => {}
+                GroupSelect(_) => {}
+                GroupSelectMenu => {}
+                MoveClientAsk(_) => {}
+                MoveClientTo(_, _) => {}
+                GroupScopeAsk => {}
+                GroupScopeSet(_) => {}
+                Unknown => {}
+            }
+        }
+
+        samples
+    }
+
     /// Табличный тест гейта авторизации: каждая строка — один Action и
     /// ожидаемый доступ для owner/GA (снято с текущего поведения диспатча).
     /// Denied проверяется отдельно на каждой строке — защита в глубину.
@@ -3354,6 +3513,22 @@ mod tests {
             (Action::GroupScopeAsk, true, false),
             (Action::GroupScopeSet(ListScope::All), true, false),
         ];
+
+        // Ассерт полноты: на каждый вариант Action (образцы из
+        // coverage_samples) в таблице выше должна найтись хотя бы одна
+        // строка — иначе новый вариант получит проверку доступа в
+        // authorize(), но проскочит мимо теста молча.
+        let table_discriminants: std::collections::HashSet<_> = table
+            .iter()
+            .map(|(action, _, _)| std::mem::discriminant(action))
+            .collect();
+        for sample in coverage_samples() {
+            assert!(
+                table_discriminants.contains(&std::mem::discriminant(&sample)),
+                "authorize_table не содержит строки для варианта {sample:?} — допишите строку в table"
+            );
+        }
+
         for (action, owner_ok, ga_ok) in &table {
             assert_eq!(
                 authorize(action, &owner, &store),

--- a/src/store/groups.rs
+++ b/src/store/groups.rs
@@ -203,13 +203,15 @@ impl Store {
 
     /// Привязка клиента к группе (или отвязка при None). Строка clients может
     /// ещё не существовать (её обычно создаёт collector.ingest) — upsert, не
-    /// трогающий first_seen/last_seen существующей строки.
+    /// трогающий first_seen/last_seen существующей строки. Если клиент был помечен
+    /// удалённым (removed_at IS NOT NULL), привязка «оживляет» его: снимает removed_at
+    /// так, что живой клиент сразу считается в квоте группы, не дожидаясь тика коллектора.
     pub fn assign_client_group(&self, name: &str, group_id: Option<i64>, now: i64) {
         if let Err(e) = self.with_conn(|c| {
             c.execute(
                 "INSERT INTO clients(name, ip, first_seen, last_seen, group_id)
                  VALUES(?1, '', ?2, ?2, ?3)
-                 ON CONFLICT(name) DO UPDATE SET group_id=?3",
+                 ON CONFLICT(name) DO UPDATE SET group_id=?3, removed_at=NULL",
                 rusqlite::params![name, now, group_id],
             )
         }) {
@@ -259,7 +261,7 @@ impl Store {
             c.execute(
                 "INSERT INTO clients(name, ip, first_seen, last_seen, group_id)
                  VALUES(?1, '', ?2, ?2, ?3)
-                 ON CONFLICT(name) DO UPDATE SET group_id=?3",
+                 ON CONFLICT(name) DO UPDATE SET group_id=?3, removed_at=NULL",
                 rusqlite::params![name, now, group_id],
             )?;
             Ok(true)
@@ -761,24 +763,47 @@ mod tests {
 
     #[test]
     fn try_assign_removed_client_in_group_counts_as_new() {
-        // «Воскресшее» имя: строка clients с этим именем и этим же group_id,
-        // но removed_at IS NOT NULL — это НЕ no-op, квота проверяется заново
-        // (живой клиент реально добавляется в группу).
+        // «Воскресшее» имя: строка clients с этим именем существует, но removed_at IS NOT NULL.
+        // При успешной привязке removed_at должен быть NULL, и воскрешённый клиент сразу
+        // считается в квоте (не дожидаясь тика коллектора).
         let store = Store::open_in_memory();
         let g = store.create_group("g", 0).unwrap();
-        store.set_group_quota(g, Some(1));
+        store.set_group_quota(g, Some(2));
         store.assign_client_group("dead", Some(g), 10);
         store
             .with_conn(|c| c.execute("UPDATE clients SET removed_at=99 WHERE name='dead'", []))
             .unwrap();
-        // Слот свободен (dead не считается) — займём его другим клиентом.
+
+        // Слот свободен (dead не считается, т.к. removed_at=99) — займём его alice.
         assert_eq!(
-            store.try_assign_client_group("alive", g, 100),
+            store.try_assign_client_group("alice", g, 100),
             QuotaAssign::Assigned
         );
-        // Теперь квота выбрана, и воскрешение dead в неё упирается.
+
+        // Теперь воскресим dead: try_assign возвращает Assigned и очищает removed_at.
         assert_eq!(
             store.try_assign_client_group("dead", g, 200),
+            QuotaAssign::Assigned
+        );
+
+        // После воскрешения removed_at должен быть NULL сразу (не дожидаясь коллектора).
+        let removed_at: Option<i64> = store
+            .with_conn(|c| {
+                c.query_row(
+                    "SELECT removed_at FROM clients WHERE name='dead'",
+                    [],
+                    |r| r.get(0),
+                )
+            })
+            .unwrap();
+        assert_eq!(removed_at, None);
+
+        // Счётчик должен отражать обоих живых клиентов сразу (без тика коллектора).
+        assert_eq!(store.group_client_count(g), 2);
+
+        // Квота выбрана: следующий new клиент не влезает (даже без коллектора).
+        assert_eq!(
+            store.try_assign_client_group("charlie", g, 300),
             QuotaAssign::Full
         );
     }
@@ -817,5 +842,60 @@ mod tests {
             .count();
         assert_eq!(assigned, 3);
         assert_eq!(store.group_client_count(g), 3);
+    }
+
+    #[test]
+    fn try_assign_move_live_client_between_groups() {
+        // Перенос живого клиента между группами: попытка положить в полную группу
+        // должна вернуть Full и оставить клиента в исходной группе; перенос в
+        // группу со свободным слотом должен удаться и изменить счётчики обеих групп.
+        let store = Store::open_in_memory();
+        let g1 = store.create_group("g1", 0).unwrap();
+        let g2 = store.create_group("g2", 0).unwrap();
+
+        store.set_group_quota(g1, Some(1));
+        store.set_group_quota(g2, Some(1));
+
+        // Привяжем клиента alice к g1
+        assert_eq!(
+            store.try_assign_client_group("alice", g1, 10),
+            QuotaAssign::Assigned
+        );
+        assert_eq!(store.group_client_count(g1), 1);
+        assert_eq!(store.group_client_count(g2), 0);
+
+        // Заполним g2
+        assert_eq!(
+            store.try_assign_client_group("bob", g2, 20),
+            QuotaAssign::Assigned
+        );
+        assert_eq!(store.group_client_count(g2), 1);
+
+        // Попытка перенести alice в полную g2 должна вернуть Full и оставить alice в g1
+        assert_eq!(
+            store.try_assign_client_group("alice", g2, 30),
+            QuotaAssign::Full
+        );
+        assert_eq!(store.client_group("alice"), Some(g1));
+        assert_eq!(store.group_client_count(g1), 1);
+        assert_eq!(store.group_client_count(g2), 1);
+
+        // Освободим g2 перемещением bob
+        let g3 = store.create_group("g3", 0).unwrap();
+        assert_eq!(
+            store.try_assign_client_group("bob", g3, 40),
+            QuotaAssign::Assigned
+        );
+        assert_eq!(store.group_client_count(g2), 0);
+
+        // Теперь перенос alice в g2 должен успешно выполниться
+        assert_eq!(
+            store.try_assign_client_group("alice", g2, 50),
+            QuotaAssign::Assigned
+        );
+        assert_eq!(store.client_group("alice"), Some(g2));
+        assert_eq!(store.group_client_count(g1), 0);
+        assert_eq!(store.group_client_count(g2), 1);
+        assert_eq!(store.group_client_count(g3), 1);
     }
 }

--- a/src/store/groups.rs
+++ b/src/store/groups.rs
@@ -24,6 +24,17 @@ pub enum GroupError {
     Db,
 }
 
+/// Итог атомарной привязки с проверкой квоты.
+#[derive(Debug, PartialEq)]
+pub enum QuotaAssign {
+    /// Привязан (или уже был живым клиентом этой группы — no-op).
+    Assigned,
+    /// Квота исчерпана либо группы уже нет: привязка не выполнена.
+    Full,
+    /// Ошибка БД (залогирована): привязка не выполнена.
+    Db,
+}
+
 pub struct InviteRow {
     pub token: String,
     pub group_id: i64,
@@ -203,6 +214,63 @@ impl Store {
             )
         }) {
             tracing::error!(error = %e, client = name, "не удалось привязать клиента к группе");
+        }
+    }
+
+    /// Атомарный вариант assign_client_group для путей, где действует квота:
+    /// проверка лимита и upsert выполняются в одном замыкании with_conn, то
+    /// есть под одним захватом мьютекса соединения — конкурирующий вызов
+    /// увидит уже обновлённый счётчик (фикс TOCTOU-гонки квоты).
+    pub fn try_assign_client_group(&self, name: &str, group_id: i64, now: i64) -> QuotaAssign {
+        use rusqlite::OptionalExtension;
+        let res = self.with_conn(|c| {
+            // Живой клиент уже в этой группе → no-op: перенос в свою группу
+            // и гонки recreate не блокируются полнотой группы.
+            let already: Option<Option<i64>> = c
+                .query_row(
+                    "SELECT group_id FROM clients WHERE name=?1 AND removed_at IS NULL",
+                    [name],
+                    |r| r.get(0),
+                )
+                .optional()?;
+            if already.flatten() == Some(group_id) {
+                return Ok(true);
+            }
+            // Нет строки группы → отказ (Full-класс): группу удалили за время
+            // диалога, привязывать не к чему.
+            let max: Option<Option<i64>> = c
+                .query_row(
+                    "SELECT max_clients FROM groups WHERE id=?1",
+                    [group_id],
+                    |r| r.get(0),
+                )
+                .optional()?;
+            let Some(max) = max else { return Ok(false) };
+            if let Some(max) = max {
+                let count: i64 = c.query_row(
+                    "SELECT COUNT(*) FROM clients WHERE group_id=?1 AND removed_at IS NULL",
+                    [group_id],
+                    |r| r.get(0),
+                )?;
+                if count >= max {
+                    return Ok(false);
+                }
+            }
+            c.execute(
+                "INSERT INTO clients(name, ip, first_seen, last_seen, group_id)
+                 VALUES(?1, '', ?2, ?2, ?3)
+                 ON CONFLICT(name) DO UPDATE SET group_id=?3",
+                rusqlite::params![name, now, group_id],
+            )?;
+            Ok(true)
+        });
+        match res {
+            Ok(true) => QuotaAssign::Assigned,
+            Ok(false) => QuotaAssign::Full,
+            Err(e) => {
+                tracing::error!(error = %e, client = name, group_id, "не удалось атомарно привязать клиента к группе");
+                QuotaAssign::Db
+            }
         }
     }
 
@@ -626,5 +694,128 @@ mod tests {
         assert!(t
             .chars()
             .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit()));
+    }
+
+    #[test]
+    fn try_assign_respects_quota() {
+        let store = Store::open_in_memory();
+        let g = store.create_group("g", 0).unwrap();
+        store.set_group_quota(g, Some(2));
+        assert_eq!(
+            store.try_assign_client_group("a", g, 10),
+            QuotaAssign::Assigned
+        );
+        assert_eq!(
+            store.try_assign_client_group("b", g, 10),
+            QuotaAssign::Assigned
+        );
+        // Третий не влезает; привязка не выполнена.
+        assert_eq!(store.try_assign_client_group("c", g, 10), QuotaAssign::Full);
+        assert_eq!(store.group_client_count(g), 2);
+        assert_eq!(store.client_group("c"), None);
+    }
+
+    #[test]
+    fn try_assign_already_in_group_is_noop_even_when_full() {
+        // Перенос в свою же группу / гонка recreate: клиент уже внутри —
+        // полная группа не должна его «выталкивать».
+        let store = Store::open_in_memory();
+        let g = store.create_group("g", 0).unwrap();
+        store.set_group_quota(g, Some(1));
+        assert_eq!(
+            store.try_assign_client_group("a", g, 10),
+            QuotaAssign::Assigned
+        );
+        assert_eq!(
+            store.try_assign_client_group("a", g, 20),
+            QuotaAssign::Assigned
+        );
+        assert_eq!(store.group_client_count(g), 1);
+    }
+
+    #[test]
+    fn try_assign_unlimited_group() {
+        let store = Store::open_in_memory();
+        let g = store.create_group("g", 0).unwrap(); // max_clients = NULL
+        for i in 0..5 {
+            let name = format!("c{i}");
+            assert_eq!(
+                store.try_assign_client_group(&name, g, 10),
+                QuotaAssign::Assigned
+            );
+        }
+        assert_eq!(store.group_client_count(g), 5);
+    }
+
+    #[test]
+    fn try_assign_missing_group_is_full() {
+        // Группу удалили за время гонки: привязка не выполняется, клиент
+        // остаётся как был (Full-класс отказа — см. спеку).
+        let store = Store::open_in_memory();
+        assert_eq!(
+            store.try_assign_client_group("a", 999, 10),
+            QuotaAssign::Full
+        );
+        assert_eq!(store.client_group("a"), None);
+    }
+
+    #[test]
+    fn try_assign_removed_client_in_group_counts_as_new() {
+        // «Воскресшее» имя: строка clients с этим именем и этим же group_id,
+        // но removed_at IS NOT NULL — это НЕ no-op, квота проверяется заново
+        // (живой клиент реально добавляется в группу).
+        let store = Store::open_in_memory();
+        let g = store.create_group("g", 0).unwrap();
+        store.set_group_quota(g, Some(1));
+        store.assign_client_group("dead", Some(g), 10);
+        store
+            .with_conn(|c| c.execute("UPDATE clients SET removed_at=99 WHERE name='dead'", []))
+            .unwrap();
+        // Слот свободен (dead не считается) — займём его другим клиентом.
+        assert_eq!(
+            store.try_assign_client_group("alive", g, 100),
+            QuotaAssign::Assigned
+        );
+        // Теперь квота выбрана, и воскрешение dead в неё упирается.
+        assert_eq!(
+            store.try_assign_client_group("dead", g, 200),
+            QuotaAssign::Full
+        );
+    }
+
+    #[test]
+    fn try_assign_db_error_is_db() {
+        let store = Store::open_in_memory();
+        let g = store.create_group("g", 0).unwrap();
+        store
+            .with_conn(|c| c.execute("DROP TABLE clients", []))
+            .unwrap();
+        assert_eq!(store.try_assign_client_group("a", g, 10), QuotaAssign::Db);
+    }
+
+    #[test]
+    fn try_assign_concurrent_never_overshoots() {
+        // Гонка N потоков за M слотов: ровно M привязок. Провал этого теста до
+        // фикса — сам смысл задачи (старый check-then-act перелетал квоту).
+        use std::sync::Arc;
+        let store = Arc::new(Store::open_in_memory());
+        let g = store.create_group("g", 0).unwrap();
+        store.set_group_quota(g, Some(3));
+        let handles: Vec<_> = (0..10)
+            .map(|i| {
+                let store = Arc::clone(&store);
+                std::thread::spawn(move || {
+                    let name = format!("c{i}");
+                    store.try_assign_client_group(&name, g, 10)
+                })
+            })
+            .collect();
+        let results: Vec<QuotaAssign> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+        let assigned = results
+            .iter()
+            .filter(|r| **r == QuotaAssign::Assigned)
+            .count();
+        assert_eq!(assigned, 3);
+        assert_eq!(store.group_client_count(g), 3);
     }
 }

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -14,7 +14,8 @@ mod stats;
 
 pub use events::{EventKind, EventRow};
 pub use groups::{
-    gen_invite_token, GroupError, GroupRow, InviteRow, InviteUse, ListScope, INVITE_TTL_SECS,
+    gen_invite_token, GroupError, GroupRow, InviteRow, InviteUse, ListScope, QuotaAssign,
+    INVITE_TTL_SECS,
 };
 pub use stats::{PeriodTotals, Sample, TrafficSummary};
 


### PR DESCRIPTION
## Что сделано

- **Гонка квоты (TOCTOU)**: проверка лимита и привязка клиента к группе
  теперь атомарны (`Store::try_assign_client_group`, один захват мьютекса
  соединения; привязка заодно «оживляет» строку — removed_at снимается,
  воскресший клиент сразу считается в квоте). Перенос — прямая замена;
  создание — ранняя проверка осталась для быстрого отказа, а проигравший
  гонку откатывается (`vpn.remove`) с сообщением «квота исчерпана».
  Многопоточный тест фиксирует отсутствие перелёта.
- **Гейт авторизации**: все callback-действия проходят через единую
  функцию `authorize` с исчерпывающим match без wildcard — новый Action
  не скомпилируется без явного решения о доступе. ~57 разбросанных
  guard'ов удалены, поведение зафиксировано табличным тестом
  (Owner / GA-свой / GA-чужой / Denied для каждого из 69 вариантов
  Action) с компайл- и runtime-страховкой полноты таблицы.

## Тесты

- store: квота на границе, no-op в своей группе, безлимит, удалённая
  группа, ошибка БД, воскресшие имена, перенос между группами, гонка
  10 потоков за 3 слота.
- handlers: таблица авторизации по всем Action, откат создания.

Закрывает tech debt #20 (третий пункт — тихий успех rename/quota —
закрыт ранее в 4322a9e).