### PR TITLE
fix(bot): не слать «Готово» после ошибки создания клиента (#40)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Format — [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioning 
   клиентов в одну группу квота могла быть превышена — проверка и привязка
   теперь атомарны; создание, проигравшее гонку, откатывается с сообщением
   «квота исчерпана» ([#20](https://github.com/ekuraev/awgram/issues/20)).
+- **«Готово» после ошибки создания**: провал добавления клиента больше не
+  завершается сообщением «Готово» — после ошибки бот возвращает главное
+  меню ([#40](https://github.com/ekuraev/awgram/issues/40)).
 
 #### ♻️ Изменено
 
@@ -28,6 +31,9 @@ Format — [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioning 
   same group could exceed the quota — the check and the binding are now
   atomic; a creation that loses the race is rolled back with a
   "quota reached" message ([#20](https://github.com/ekuraev/awgram/issues/20)).
+- **"Done" after a failed add**: a failed client creation no longer ends
+  with a "Done" message — on error the bot now returns the main menu
+  ([#40](https://github.com/ekuraev/awgram/issues/40)).
 
 #### ♻️ Changed
 

--- a/src/bot/handlers.rs
+++ b/src/bot/handlers.rs
@@ -1263,8 +1263,18 @@ async fn finish_add(
             return;
         }
         Err(e) => {
+            // Клиент не создан — ранний return, чтобы общий хвост не слал
+            // «Готово» следом за ошибкой (#40). Клавиатуру возвращаем: без
+            // неё пользователь оставался бы без меню после сбоя.
             tracing::error!(error = %e, "add провалился");
-            let _ = bot.send_message(chat, i18n::error_text(lang, &e)).await;
+            if let Some(m) = waiting {
+                let _ = bot.delete_message(chat, m.id).await;
+            }
+            let _ = bot
+                .send_message(chat, i18n::error_text(lang, &e))
+                .reply_markup(home)
+                .await;
+            return;
         }
     }
     if let Some(m) = waiting {


### PR DESCRIPTION
Ветка `Err(e)` после `vpn.add` в `do_add_client` слала `error_text` и проваливалась в общий хвост функции — пользователь получал «⚠️ ошибка», а следом «✅ Готово», хотя клиент не создан.

Теперь ветка завершается ранним `return` по образцу соседней `Err(ClientExists)`: waiting-сообщение удаляется, ошибка уходит с главным меню (чтобы не бросать пользователя без клавиатуры), «Готово» не шлётся.

Юнит-теста нет: последовательность Telegram-сообщений в хэндлерах не тестируется без мока Telegram-сервера (осознанно вне скоупа, см. #20); прогнан полный сьют.

Closes #40