### PR TITLE
fix(vpn): ретрай ETXTBSY при запуске manage-скрипта

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Format — [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioning 
 - **«Готово» после ошибки создания**: провал добавления клиента больше не
   завершается сообщением «Готово» — после ошибки бот возвращает главное
   меню ([#40](https://github.com/ekuraev/awgram/issues/40)).
+- **Устойчивость к «Text file busy»**: запуск manage-скрипта теперь
+  переживает короткое окно, когда файл открыт на запись (например,
+  `awgram-setup update` переписывает скрипт под работающим ботом) —
+  spawn ретраится до 200 мс вместо немедленной ошибки.
 
 #### ♻️ Изменено
 
@@ -34,6 +38,10 @@ Format — [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioning 
 - **"Done" after a failed add**: a failed client creation no longer ends
   with a "Done" message — on error the bot now returns the main menu
   ([#40](https://github.com/ekuraev/awgram/issues/40)).
+- **Resilience to "Text file busy"**: launching the manage script now
+  survives a brief window when the file is open for writing (e.g.
+  `awgram-setup update` rewriting the script under a running bot) — the
+  spawn retries for up to 200 ms instead of failing immediately.
 
 #### ♻️ Changed
 

--- a/src/vpn/runner.rs
+++ b/src/vpn/runner.rs
@@ -43,7 +43,29 @@ fn build_cmd(spec: &RunSpec<'_>, args: &[&str]) -> Command {
 /// недостижимыми в проде. Timeout по-прежнему → Error::Timeout.
 pub async fn run(spec: &RunSpec<'_>, args: &[&str]) -> Result<(String, i32)> {
     let mut cmd = build_cmd(spec, args);
-    let child = cmd.spawn()?;
+    // ETXTBSY при execve: скрипт в этот момент открыт кем-то на запись.
+    // Два легитимных источника: `awgram-setup update` переписывает
+    // manage-скрипт под работающим ботом, и fork-окно параллельного spawn
+    // (другой поток процесса успел сделать fork, пока чей-то fd записи ещё
+    // открыт, — проявлялось флейком тестов в Linux CI). Окно — микросекунды
+    // и миллисекунды, поэтому короткий ретрай надёжно его пережидает, не
+    // маскируя настоящие ошибки запуска.
+    const BUSY_RETRIES: u32 = 10;
+    const BUSY_PAUSE: Duration = Duration::from_millis(20);
+    let mut busy_attempts = 0;
+    let child = loop {
+        match cmd.spawn() {
+            Ok(c) => break c,
+            Err(e)
+                if e.kind() == std::io::ErrorKind::ExecutableFileBusy
+                    && busy_attempts < BUSY_RETRIES =>
+            {
+                busy_attempts += 1;
+                tokio::time::sleep(BUSY_PAUSE).await;
+            }
+            Err(e) => return Err(e.into()),
+        }
+    };
     let dur = Duration::from_secs(spec.timeout_secs);
     let output = match timeout(dur, child.wait_with_output()).await {
         Ok(res) => res?,
@@ -105,5 +127,33 @@ mod tests {
         };
         let (out, _) = run(&spec, &[]).await.unwrap();
         assert_eq!(out, "unset");
+    }
+
+    #[tokio::test]
+    async fn run_retries_while_script_briefly_busy() {
+        // Детерминированная эмуляция ETXTBSY-гонки (см. комментарий в run):
+        // держим fd записи скрипта открытым 50 мс параллельно с запуском.
+        // На Linux execve в этом окне даёт «Text file busy» — без ретрая
+        // тест падает; macOS ETXTBSY для скриптов не выдаёт, там тест
+        // проверяет только успешный запуск.
+        let dir = tempfile::tempdir().unwrap();
+        let script = write_script(&dir, "#!/bin/sh\nprintf 'ok'\n");
+        let held = std::fs::OpenOptions::new()
+            .write(true)
+            .open(&script)
+            .unwrap();
+        let holder = std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(50));
+            drop(held);
+        });
+        let spec = RunSpec {
+            script: &script,
+            sudo_prefix: "",
+            timeout_secs: 5,
+            extra_env: &[],
+        };
+        let (out, code) = run(&spec, &[]).await.unwrap();
+        assert_eq!((out.as_str(), code), ("ok", 0));
+        holder.join().unwrap();
     }
 }


### PR DESCRIPTION
`run()` падал с «Text file busy», если в момент execve скрипт был открыт кем-то на запись. Два легитимных источника:

- **прод**: `awgram-setup update` переписывает manage-скрипт под работающим ботом;
- **тесты**: классическая fork-гонка параллельного test-раннера — поток B делает fork, пока у потока A ещё открыт fd записи stub-скрипта; ребёнок B наследует fd до своего exec, и execve скрипта A ловит ETXTBSY (проявилось флейком `no_extra_env_means_unset` в CI на PR #41, rerun прошёл).

Фикс — ограниченный ретрай в `run()` (до 10 попыток × 20 мс, максимум 200 мс) только для `ErrorKind::ExecutableFileBusy`; остальные ошибки запуска отдаются сразу. Тот же подход, что в cargo для этой гонки.

Тест: параллельно с запуском держим fd записи скрипта открытым 50 мс — на Linux без ретрая это детерминированный ETXTBSY (красное состояние наблюдалось в CI), с ретраем — успех; на macOS ядро ETXTBSY для скриптов не выдаёт, там тест проверяет только успешный запуск (зафиксировано в комментарии).