### PR TITLE
fix(bot): тупик «Без группы», кнопка «Клиенты группы», совместимость v5.23.0 (#20)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,63 @@ Format — [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioning 
 
 ### 🇷🇺 Русский
 
-_Пусто — изменений после v0.8.1 пока нет._
+_Пусто — изменений после v0.8.2 пока нет._
 
 ### 🇬🇧 English
 
-_Empty — no changes since v0.8.1 yet._
+_Empty — no changes since v0.8.2 yet._
+
+## [0.8.2] — 2026-08-03
+
+### 🇷🇺 Русский
+
+#### ✨ Добавлено
+
+- **Кнопка «Клиенты группы»** в карточке группы: открывает список клиентов
+  с фильтром по этой группе
+  ([#20](https://github.com/ekuraev/awgram/issues/20)).
+
+#### 🐛 Исправлено
+
+- **Тупик фильтра «Без группы»**: когда все клиенты распределены по группам
+  (или под липкий статус-фильтр никто не попал), раздел «Клиенты» больше не
+  запирается на «клиентов нет» — экран пустой выборки сохраняет кнопки смены
+  статус-фильтра и группового фильтра, а текст различает «клиентов нет
+  вообще» и «под фильтр никто не попал»
+  ([#20](https://github.com/ekuraev/awgram/issues/20)).
+
+#### ♻️ Изменено
+
+- **Совместимость с инсталлером**: поддерживаемая версия —
+  [v5.23.0](https://github.com/bivlked/amneziawg-installer/releases/tag/v5.23.0)
+  (сверен `--json`-контракт: v5.22.0 добавил предупреждение о рассинхроне
+  `awgsetup_cfg.init` только в stderr, v5.23.0 меняет только установщики);
+  минимальная — по-прежнему v5.21.0.
+
+### 🇬🇧 English
+
+#### ✨ Added
+
+- **"Group clients" button** on the group card: opens the client list
+  filtered to that group
+  ([#20](https://github.com/ekuraev/awgram/issues/20)).
+
+#### 🐛 Fixed
+
+- **"No group" filter dead end**: when every client is assigned to a group
+  (or the sticky status filter matches nobody), the "Clients" section no
+  longer locks up on "no clients" — the empty-selection screen keeps the
+  status-filter and group-filter buttons, and the text distinguishes
+  "no clients at all" from "nothing matches the filter"
+  ([#20](https://github.com/ekuraev/awgram/issues/20)).
+
+#### ♻️ Changed
+
+- **Installer compatibility**: the supported version is now
+  [v5.23.0](https://github.com/bivlked/amneziawg-installer/releases/tag/v5.23.0)
+  (`--json` contract verified: v5.22.0 adds an `awgsetup_cfg.init` drift
+  warning to stderr only, v5.23.0 only changes the installers); the minimum
+  stays v5.21.0.
 
 ## [0.8.1] — 2026-07-31
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "awgram"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "rand 0.10.2",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "awgram"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 description = "Telegram bot for managing AmneziaWG VPN clients"
 license = "MIT"

--- a/README.en.md
+++ b/README.en.md
@@ -127,13 +127,15 @@ The bot is a layer on top of `manage_amneziawg.sh` from
 and depends directly on its interface.
 
 - **Supported installer version:
-  [v5.21.2](https://github.com/bivlked/amneziawg-installer/releases/tag/v5.21.2)**
-  (tested against it). Minimum is
+  [v5.23.0](https://github.com/bivlked/amneziawg-installer/releases/tag/v5.23.0)**
+  (`--json` contract verified). Minimum is
   [v5.21.0](https://github.com/bivlked/amneziawg-installer/releases/tag/v5.21.0);
   older v5.20.x releases are not supported — the bot uses the extended
   `--json` interface for management commands introduced in v5.21.0.
-  v5.21.1/v5.21.2 are validation bugfixes (port normalisation in `check`,
-  numeric counters in `stats --json`); the JSON contract is unchanged.
+  v5.21.1–v5.23.0 leave the JSON contract unchanged: v5.21.1/v5.21.2 are
+  validation bugfixes, v5.22.0 added an `awgsetup_cfg.init` drift warning
+  to `regen`/`check` (goes to stderr, stdout JSON untouched), and v5.23.0
+  only changes the installers (kernel module handling on older kernels).
 - Subcommands used: `add`, `remove`, `list`, `stats`, `regen`, `modify`,
   `backup`, `restore`, `check`, `restart`, `repair-module` — all with `--json`.
 

--- a/README.md
+++ b/README.md
@@ -126,13 +126,15 @@ webhook), который живёт на том же VPS, что и VPN. Кон�
 и напрямую зависит от его интерфейса.
 
 - **Поддерживаемая версия инсталлера:
-  [v5.21.2](https://github.com/bivlked/amneziawg-installer/releases/tag/v5.21.2)**
-  (проверено с ней). Минимальная —
+  [v5.23.0](https://github.com/bivlked/amneziawg-installer/releases/tag/v5.23.0)**
+  (сверен `--json`-контракт). Минимальная —
   [v5.21.0](https://github.com/bivlked/amneziawg-installer/releases/tag/v5.21.0);
   более старые v5.20.x не поддерживаются — бот использует расширенный
   `--json`-интерфейс команд управления, появившийся в v5.21.0.
-  v5.21.1/v5.21.2 — багфиксы валидации (нормализация порта в `check`,
-  числовые счётчики в `stats --json`); JSON-контракт не изменился.
+  v5.21.1–v5.23.0 JSON-контракт не меняли: v5.21.1/v5.21.2 — багфиксы
+  валидации, v5.22.0 добавил в `regen`/`check` предупреждение о рассинхроне
+  `awgsetup_cfg.init` (уходит в stderr, stdout-JSON не затронут),
+  v5.23.0 — изменения только в установщике (модуль ядра на старых ядрах).
 - Используемые подкоманды: `add`, `remove`, `list`, `stats`, `regen`,
   `modify`, `backup`, `restore`, `check`, `restart`, `repair-module` —
   все с `--json`.

--- a/src/bot/handlers.rs
+++ b/src/bot/handlers.rs
@@ -1441,11 +1441,32 @@ async fn finish_bulk(
     }
 }
 
+/// Экран пустого списка клиентов. Клиентов нет вообще (`total == 0`) —
+/// «Пока нет клиентов» + домашняя клавиатура. Пусто из-за фильтра/скоупа —
+/// текст про фильтр + клавиатура с кнопками смены фильтра и скоупа: липкие
+/// настройки иначе делают раздел недоступным (#20 — «Без группы» при
+/// полностью распределённых клиентах).
+fn empty_list_screen(
+    lang: Lang,
+    total: usize,
+    filter: crate::vpn::model::ClientFilter,
+    is_owner: bool,
+    home: InlineKeyboardMarkup,
+) -> (String, InlineKeyboardMarkup) {
+    if total == 0 {
+        (i18n::clients_empty(lang), home)
+    } else {
+        (
+            i18n::clients_empty_filtered(lang),
+            menu::clients_empty_menu(lang, filter, is_owner),
+        )
+    }
+}
+
 /// Рендерит экран списка клиентов: list_enriched → filter+sort → expiries →
 /// title → clients_list. Общая логика для Action::List / Action::Page /
 /// Action::SetListFilter (различаются только страницей и тем, кто читает/
-/// устанавливает фильтр из настроек). Пустой список (до или после фильтра) →
-/// friendly-сообщение + главное меню.
+/// устанавливает фильтр из настроек). Пустой список — empty_list_screen.
 #[allow(clippy::too_many_arguments)]
 async fn render_clients_list(
     bot: &Bot,
@@ -1478,7 +1499,8 @@ async fn render_clients_list(
                 .filter(|c| scope.admits(settings.client_group(&c.name)))
                 .collect();
             if clients.is_empty() {
-                edit_or_send(bot, chat, msg_id, i18n::clients_empty(lang), home).await;
+                let (text, kb) = empty_list_screen(lang, all_clients.len(), filter, is_owner, home);
+                edit_or_send(bot, chat, msg_id, text, kb).await;
                 return;
             }
             // Полный вектор (не страница): clients_list индексирует expiries[i]
@@ -3134,6 +3156,38 @@ mod tests {
     }
 
     #[test]
+    fn empty_list_screen_no_clients_keeps_home_menu() {
+        // Клиентов нет вообще — фильтровать нечего, остаётся домашнее меню.
+        let home = menu::main_menu(Lang::Ru);
+        let (text, kb) = empty_list_screen(
+            Lang::Ru,
+            0,
+            crate::vpn::model::ClientFilter::All,
+            true,
+            home.clone(),
+        );
+        assert_eq!(text, i18n::clients_empty(Lang::Ru));
+        assert_eq!(kb, home);
+    }
+
+    #[test]
+    fn empty_list_screen_filtered_keeps_filter_controls() {
+        // Тупик #20: клиенты есть, но липкий фильтр/скоуп дал пустую
+        // выборку — экран обязан оставить кнопки смены фильтра и скоупа.
+        let (text, kb) = empty_list_screen(
+            Lang::Ru,
+            3,
+            crate::vpn::model::ClientFilter::All,
+            true,
+            menu::main_menu(Lang::Ru),
+        );
+        assert_eq!(text, i18n::clients_empty_filtered(Lang::Ru));
+        let dbg = format!("{kb:?}");
+        assert!(dbg.contains("\"gscope\""));
+        assert!(dbg.contains("listfilter:all"));
+    }
+
+    #[test]
     fn truncate_for_message_respects_char_boundary() {
         // Трёхбайтовый символ: 3500 не кратно 3 → индекс попадает внутрь
         // символа, обрезка должна откатиться к границе, а не паниковать.
@@ -3233,6 +3287,7 @@ mod tests {
             menu::ga_main_menu(Lang::Ru, true),
             menu::move_client_menu(Lang::Ru, "alice", &[sample_group()]),
             menu::group_scope_menu(Lang::Ru, &[sample_group()]),
+            menu::clients_empty_menu(Lang::Ru, crate::vpn::model::ClientFilter::All, true),
             menu::slug_recommend_menu(Lang::Ru),
         ];
 

--- a/src/bot/menu.rs
+++ b/src/bot/menu.rs
@@ -51,6 +51,10 @@ pub fn group_card_menu(lang: Lang, id: i64, has_invite: bool) -> InlineKeyboardM
         cb(&i18n::btn_group_invite(lang), &format!("g:inv:{id}"))
     };
     InlineKeyboardMarkup::new(vec![
+        // «Клиенты группы» (#20) — существующий скоуп-фильтр списка: тот же
+        // callback, что и на экране выбора группового фильтра (gscope:{id}),
+        // устанавливает липкий фильтр владельца и рендерит список группы.
+        vec![cb(&i18n::btn_group_clients(lang), &format!("gscope:{id}"))],
         vec![
             cb(&i18n::btn_group_rename(lang), &format!("g:ren:{id}")),
             cb(&i18n::btn_group_quota(lang), &format!("g:quota:{id}")),
@@ -461,6 +465,22 @@ pub fn clients_list(
     }
     rows.push(vec![cb(&i18n::btn_back(lang), "menu")]);
     InlineKeyboardMarkup::new(rows)
+}
+
+/// Клавиатура пустой выборки списка: клиенты на сервере есть, но липкий
+/// статус-фильтр/групповой скоуп ничего не пропустил. Обязана оставлять
+/// кнопки смены фильтра и (владельцу) скоупа — иначе «Без группы» при
+/// полностью распределённых клиентах запирает раздел клиентов (#20).
+pub fn clients_empty_menu(
+    lang: Lang,
+    current_filter: ClientFilter,
+    is_owner: bool,
+) -> InlineKeyboardMarkup {
+    let mut filter_btns = filter_row(lang, current_filter);
+    if is_owner {
+        filter_btns.push(cb(&i18n::btn_scope(lang), "gscope"));
+    }
+    InlineKeyboardMarkup::new(vec![filter_btns, vec![cb(&i18n::btn_back(lang), "menu")]])
 }
 
 pub fn client_card(lang: Lang, name: &str, is_owner: bool) -> InlineKeyboardMarkup {
@@ -1456,5 +1476,30 @@ mod tests {
             }
             _ => panic!("expected callback data"),
         }
+    }
+
+    #[test]
+    fn clients_empty_menu_keeps_filter_and_scope_controls() {
+        // Тупик #20: пустая выборка при липком фильтре/скоупе обязана
+        // оставлять кнопки смены статус-фильтра и группового фильтра —
+        // иначе «Без группы» без клиентов запирает раздел клиентов.
+        let data = all_callback_data(&clients_empty_menu(Lang::Ru, ClientFilter::All, true));
+        assert!(data.contains(&"gscope".to_string()));
+        assert!(data.contains(&"listfilter:all".to_string()));
+        assert!(data.contains(&"menu".to_string()));
+    }
+
+    #[test]
+    fn clients_empty_menu_hides_scope_for_group_admin() {
+        let data = all_callback_data(&clients_empty_menu(Lang::Ru, ClientFilter::All, false));
+        assert!(!data.contains(&"gscope".to_string()));
+        assert!(data.contains(&"listfilter:all".to_string()));
+    }
+
+    #[test]
+    fn group_card_menu_has_group_clients_button() {
+        // «Клиенты группы» (#20): открывает список клиентов с фильтром группы.
+        let data = all_callback_data(&group_card_menu(Lang::Ru, 7, false));
+        assert!(data.contains(&"gscope:7".to_string()));
     }
 }

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -508,6 +508,16 @@ pub fn clients_empty(lang: Lang) -> String {
     }
     .to_string()
 }
+/// Клиенты на сервере есть, но текущий фильтр/групповой скоуп ничего не
+/// пропустил — текст обязан отличаться от clients_empty, чтобы не врать
+/// «клиентов нет» при непустом сервере (#20).
+pub fn clients_empty_filtered(lang: Lang) -> String {
+    match lang {
+        Lang::Ru => "Под текущий фильтр не попал ни один клиент.",
+        Lang::En => "No clients match the current filter.",
+    }
+    .to_string()
+}
 pub fn clients_title(lang: Lang) -> String {
     match lang {
         Lang::Ru => "👥 <b>Клиенты</b>:",
@@ -1236,6 +1246,13 @@ pub fn group_card(
             )
         }
     }
+}
+pub fn btn_group_clients(lang: Lang) -> String {
+    match lang {
+        Lang::Ru => "👥 Клиенты группы",
+        Lang::En => "👥 Group clients",
+    }
+    .to_string()
 }
 pub fn btn_group_rename(lang: Lang) -> String {
     match lang {


### PR DESCRIPTION
Фоллоу-апы по комментариям в #20 плюс актуализация совместимости с инсталлером; подготовлен релиз v0.8.2.

## Исправлено
- **Тупик фильтра «Без группы»**: когда все клиенты распределены по группам (или под липкий статус-фильтр никто не попал), раздел «Клиенты» запирался на «клиентов нет» без возможности сменить фильтр. Экран пустой выборки теперь сохраняет ряд статус-фильтров и кнопку группового фильтра, а текст различает «клиентов нет вообще» и «под фильтр никто не попал».

## Добавлено
- **Кнопка «Клиенты группы»** в карточке группы — открывает список клиентов с фильтром по этой группе (переиспользован существующий callback `gscope:{id}`, действие owner-only, как и вся карточка).

## Совместимость с инсталлером
- Поддерживаемая версия в README (RU+EN) поднята до **v5.23.0**. Сверен `--json`-контракт manage-скрипта v5.21.2 → v5.23.0: v5.22.0 добавил в `regen`/`check` предупреждение о рассинхроне `awgsetup_cfg.init` (только stderr, rc не меняется; бот парсит stdout — контракт цел), v5.23.0 меняет только установщики. Минимальная версия по-прежнему v5.21.0, код бота адаптации не потребовал.

## Релиз
- `chore(release): v0.8.2` — секция CHANGELOG (ru/en), бамп `Cargo.toml`/`Cargo.lock`.

## Тесты
- RED→GREEN: новые тесты на меню пустой выборки, кнопку карточки группы и `empty_list_screen`; новая клавиатура включена в контрактный тест «каждый callback парсится в известный Action».
- `cargo test`: 371 passed, 0 failed; clippy без замечаний; fmt чистый.