### PR TITLE
chore(deps): обновить chacha20 (yanked 0.10.1), не бампить reqwest по major

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,11 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    ignore:
+      # Версия reqwest едет за teloxide (teloxide-core 0.13 -> reqwest 0.12):
+      # major-бамп не соберётся, пока teloxide сам не перейдёт на новый reqwest.
+      - dependency-name: reqwest
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: github-actions
     directory: "/"
     schedule:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,9 +139,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures",


### PR DESCRIPTION
## Что сделано

- `cargo update -p chacha20`: 0.10.1 → 0.10.2. Версия 0.10.1 отозвана (yanked) на crates.io, а `deny.toml` запрещает yanked-крейты — из-за этого плановый запуск **Deps audit** от 2026-08-31 падал с `error[yanked]`. Крейт приходит транзитивно через `rand 0.10`, код не меняется.
- `dependabot.yml`: игнорировать major-бампы `reqwest`. Версия reqwest едет за teloxide (`teloxide-core 0.13` требует `reqwest 0.12`), поэтому PR вида #50 не собирается — в дереве оказываются два reqwest и `reqwest::Proxy` в `src/net.rs` не совпадает по типу. Minor/patch-бампы остаются.

## Проверка

- `cargo deny --all-features check advisories licenses` — `advisories ok, licenses ok`
- `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `cargo test` — зелёные

Closes #50 (закрывается отдельно с пояснением).

https://claude.ai/code/session_015g7dXFLA9QdgeERbHkvq3J