### PR TITLE
fix(bot): одинаковая ширина инлайн-кнопок на всех экранах

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,29 @@
 Формат — [Keep a Changelog](https://keepachangelog.com/ru/1.1.0/), версионирование — [SemVer](https://semver.org/lang/ru/).
 Format — [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioning — [SemVer](https://semver.org/).
 
+## [Unreleased]
+
+### 🇷🇺 Русский
+
+#### 🐛 Исправлено
+
+- **Ширина инлайн-кнопок больше не «плавает» между экранами.** Клиент Telegram
+  подгоняет клавиатуру под ширину пузыря сообщения: короткий заголовок давал
+  широкое меню, а многострочный текст (статистика, карточка) — узкое, с
+  обрезанными подписями вроде «Поч…модуля». Теперь к тексту каждого экрана с
+  клавиатурой добавляется невидимая строка-распорка, и пузырь с кнопками везде
+  одной ширины.
+
+### 🇬🇧 English
+
+#### 🐛 Fixed
+
+- **Inline button width no longer drifts between screens.** Telegram clients
+  size the keyboard to the message bubble: a short title produced a wide menu,
+  while multi-line text (stats, client card) squeezed it and truncated labels.
+  Every screen with a keyboard now carries an invisible spacer line, so the
+  bubble and buttons have the same width everywhere.
+
 ## [0.10.0] — 2026-09-03
 
 ### 🇷🇺 Русский

--- a/src/bot/handlers.rs
+++ b/src/bot/handlers.rs
@@ -527,6 +527,7 @@ async fn edit_or_send(
     text: String,
     kb: InlineKeyboardMarkup,
 ) {
+    let text = render::pad_width(&text);
     let edit = bot
         .edit_message_text(chat, msg_id, text.clone())
         .reply_markup(kb.clone())
@@ -675,7 +676,7 @@ async fn finish_below(
 ) {
     let _ = bot.delete_message(chat, msg_id).await;
     let _ = bot
-        .send_message(chat, text)
+        .send_message(chat, render::pad_width(&text))
         .reply_markup(kb)
         .parse_mode(ParseMode::Html)
         .await;
@@ -1174,10 +1175,13 @@ async fn message_handler(
                 // multi по факту: пользователь мог уже быть админом других
                 // групп — кнопку смены группы прячем только при единственной.
                 let multi = settings.admin_group_ids(uid).len() > 1;
-                bot.send_message(msg.chat.id, i18n::joined_group(lang, &gname))
-                    .parse_mode(ParseMode::Html)
-                    .reply_markup(menu::ga_main_menu(lang, multi))
-                    .await?;
+                bot.send_message(
+                    msg.chat.id,
+                    render::pad_width(&i18n::joined_group(lang, &gname)),
+                )
+                .parse_mode(ParseMode::Html)
+                .reply_markup(menu::ga_main_menu(lang, multi))
+                .await?;
                 // Уведомить владельцев о новом админе.
                 for owner in &cfg.admin_ids {
                     let _ = bot
@@ -1192,10 +1196,13 @@ async fn message_handler(
             crate::store::InviteUse::AlreadyAdmin(gid) => {
                 let gname = settings.group(gid).map(|g| g.name).unwrap_or_default();
                 let multi = settings.admin_group_ids(uid).len() > 1;
-                bot.send_message(msg.chat.id, i18n::joined_group(lang, &gname))
-                    .parse_mode(ParseMode::Html)
-                    .reply_markup(menu::ga_main_menu(lang, multi))
-                    .await?;
+                bot.send_message(
+                    msg.chat.id,
+                    render::pad_width(&i18n::joined_group(lang, &gname)),
+                )
+                .parse_mode(ParseMode::Html)
+                .reply_markup(menu::ga_main_menu(lang, multi))
+                .await?;
             }
             crate::store::InviteUse::Invalid => {
                 bot.send_message(msg.chat.id, i18n::invite_invalid(lang))
@@ -1948,21 +1955,27 @@ async fn message_handler(
                     Role::GroupAdmin(groups) => match current_ga_group(&settings, uid, groups) {
                         Some(gid) => {
                             let gname = settings.group(gid).map(|g| g.name).unwrap_or_default();
-                            bot.send_message(msg.chat.id, i18n::ga_menu_title(lang, &gname))
-                                .reply_markup(menu::ga_main_menu(lang, groups.len() > 1))
-                                .parse_mode(ParseMode::Html)
-                                .await?;
+                            bot.send_message(
+                                msg.chat.id,
+                                render::pad_width(&i18n::ga_menu_title(lang, &gname)),
+                            )
+                            .reply_markup(menu::ga_main_menu(lang, groups.len() > 1))
+                            .parse_mode(ParseMode::Html)
+                            .await?;
                         }
                         None => {
                             let rows: Vec<_> =
                                 groups.iter().filter_map(|g| settings.group(*g)).collect();
-                            bot.send_message(msg.chat.id, i18n::select_group_title(lang))
-                                .reply_markup(menu::group_select_menu(lang, &rows))
-                                .await?;
+                            bot.send_message(
+                                msg.chat.id,
+                                render::pad_width(&i18n::select_group_title(lang)),
+                            )
+                            .reply_markup(menu::group_select_menu(lang, &rows))
+                            .await?;
                         }
                     },
                     _ => {
-                        bot.send_message(msg.chat.id, i18n::menu_title(lang))
+                        bot.send_message(msg.chat.id, render::pad_width(&i18n::menu_title(lang)))
                             .reply_markup(menu::main_menu(lang))
                             .parse_mode(ParseMode::Html)
                             .await?;

--- a/src/bot/render.rs
+++ b/src/bot/render.rs
@@ -6,6 +6,27 @@ use crate::i18n::{self, html_escape, Lang};
 use crate::store::{EventRow, TrafficSummary};
 use crate::vpn::model::{format_expiry, format_handshake, human_bytes, AddResult, Client};
 
+/// Символ «пустого» шрифта Braille: невидим, но занимает ширину, и Telegram
+/// не обрезает его как пробел в конце сообщения.
+pub const WIDTH_SPACER_CHAR: char = '\u{2800}';
+/// Длина строки-распорки. Подобрана так, чтобы пузырь на десктопе растягивался
+/// до естественной ширины главного меню; на телефоне пузырь и так широкий.
+pub const WIDTH_SPACER_LEN: usize = 50;
+
+/// Добавляет к тексту невидимую строку-распорку.
+///
+/// Ширину инлайн-клавиатуры задаёт клиент Telegram по ширине пузыря: короткий
+/// заголовок даёт широкое меню, многострочный текст с недлинными строками —
+/// узкое, с обрезанными подписями. Распорка делает самую длинную строку
+/// одинаковой на всех экранах, и клавиатура перестаёт «плавать».
+pub fn pad_width(text: &str) -> String {
+    let spacer: String = std::iter::repeat_n(WIDTH_SPACER_CHAR, WIDTH_SPACER_LEN).collect();
+    if text.ends_with(&spacer) {
+        return text.to_string();
+    }
+    format!("{text}\n{spacer}")
+}
+
 pub fn format_client_card(
     lang: Lang,
     c: &Client,
@@ -492,6 +513,30 @@ mod tests {
         ];
         let text = format_client_history(Lang::Ru, "alice", &events, now);
         assert!(text.contains("(1 ч)")); // сессия 3600 с = 60 мин
+    }
+
+    #[test]
+    fn pad_width_appends_spacer_line() {
+        let out = pad_width("hello");
+        assert!(
+            out.starts_with("hello\n"),
+            "текст сохраняется, распорка — отдельной строкой"
+        );
+        let spacer = &out["hello\n".len()..];
+        assert_eq!(spacer.chars().count(), WIDTH_SPACER_LEN);
+        assert!(spacer.chars().all(|c| c == WIDTH_SPACER_CHAR));
+    }
+
+    #[test]
+    fn pad_width_is_idempotent() {
+        let once = pad_width("hello");
+        assert_eq!(pad_width(&once), once);
+    }
+
+    #[test]
+    fn pad_width_spacer_is_html_safe() {
+        let out = pad_width("x");
+        assert!(!out[1..].contains(['<', '>', '&']));
     }
 
     #[test]


### PR DESCRIPTION
## Что сделано

Ширину инлайн-клавиатуры задаёт клиент Telegram по ширине пузыря сообщения. Короткий заголовок «🔐 AmneziaWG» растягивал пузырь до естественной ширины меню, а многострочный текст с недлинными строками (статистика, карточка клиента) фиксировал пузырь по самой длинной строке и ужимал кнопки: парные подписи обрезались («Поч…модуля»).

- К тексту каждого экрана с клавиатурой добавляется невидимая строка-распорка из пустых символов Braille (U+2800). Они занимают ширину, но не видны, и Telegram не срезает их как пробелы в конце сообщения. Самая длинная строка становится одинаковой на всех экранах, и клавиатура перестаёт «плавать».
- Помощник `pad_width` в `render.rs`, идемпотентный. Подключён в `edit_or_send`/`finish_below` и в прямые отправки меню при `/start`, выборе группы и вступлении по инвайту. Индикатор прогресса и экран выбора языка не тронуты.
- Длина распорки — константа `WIDTH_SPACER_LEN` (50), подбирается по факту.

## Проверка

- `cargo test`: 474 прошли, clippy чистый.
- Вручную: главное меню и статистика на macOS должны быть одной ширины, «Починка модуля» без обрезки; на телефоне проверить, не появилась ли лишняя пустая строка под текстом.
