### PR TITLE
fix(bot): групповой фильтр списка клиентов виден в заголовке, на кнопке «🗂» и на экране выбора

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,34 @@
 Формат — [Keep a Changelog](https://keepachangelog.com/ru/1.1.0/), версионирование — [SemVer](https://semver.org/lang/ru/).
 Format — [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioning — [SemVer](https://semver.org/).
 
+## [Unreleased]
+
+### 🇷🇺 Русский
+
+#### 🐛 Исправлено
+
+- **Групповой фильтр списка клиентов больше не невидим.** Кнопка «🗂» и
+  «👥 Клиенты группы» в карточке группы ставят владельцу липкий фильтр по
+  группе, а список при этом выглядел как обычный: заголовок «Клиенты:»,
+  фильтр «✅ Все» — и один клиент из четырёх без объяснений. Теперь заголовок
+  показывает группу и счётчик («Клиенты — 🗂 family (1 из 4)»), кнопка «🗂»
+  несёт имя группы, на экране «Показывать клиентов» текущий пункт отмечен ✅.
+  Фильтр на удалённую группу сбрасывается на «Все группы», а не прячет всех
+  клиентов насовсем.
+
+### 🇬🇧 English
+
+#### 🐛 Fixed
+
+- **The group filter of the client list is no longer invisible.** The «🗂»
+  button and «👥 Group clients» on a group card set a sticky per-group filter
+  for the owner, yet the list looked ordinary: the «Clients:» title, the
+  «✅ All» filter — and one client out of four with no explanation. The title
+  now shows the group and a counter («Clients — 🗂 family (1 of 4)»), the «🗂»
+  button carries the group name, and the current choice is marked ✅ on the
+  «Show clients» screen. A filter pointing at a deleted group falls back to
+  «All groups» instead of hiding every client for good.
+
 ## [0.11.0] — 2026-09-05
 
 ### 🇷🇺 Русский

--- a/src/bot/handlers.rs
+++ b/src/bot/handlers.rs
@@ -2529,6 +2529,7 @@ fn empty_list_screen(
     total: usize,
     filter: crate::vpn::model::ClientFilter,
     is_owner: bool,
+    scope_label: Option<&str>,
     home: InlineKeyboardMarkup,
 ) -> (String, InlineKeyboardMarkup) {
     if total == 0 {
@@ -2536,8 +2537,32 @@ fn empty_list_screen(
     } else {
         (
             i18n::clients_empty_filtered(lang),
-            menu::clients_empty_menu(lang, filter, is_owner),
+            menu::clients_empty_menu(lang, filter, is_owner, scope_label),
         )
+    }
+}
+
+/// Подпись текущего группового скоупа для заголовка списка и кнопки «🗂».
+/// Только владельцу: групповой админ и так видит лишь свою группу, а
+/// подпись со счётчиком «из N» раскрыла бы ему число клиентов всего сервера.
+fn scope_label_for(
+    lang: Lang,
+    settings: &Store,
+    scope: ListScope,
+    is_owner: bool,
+) -> Option<String> {
+    if !is_owner {
+        return None;
+    }
+    match scope {
+        ListScope::All => None,
+        ListScope::NoGroup => Some(i18n::no_group_label(lang)),
+        ListScope::Group(g) => Some(
+            settings
+                .group(g)
+                .map(|g| g.name)
+                .unwrap_or_else(|| format!("#{g}")),
+        ),
     }
 }
 
@@ -2576,8 +2601,27 @@ async fn render_clients_list(
                 .into_iter()
                 .filter(|c| scope.admits(settings.client_group(&c.name)))
                 .collect();
+            // Липкий скоуп обязан быть виден: в заголовке и на кнопке «🗂».
+            // Групповому админу подписи нет, и «всего» для него — размер его
+            // группы, а не всего сервера.
+            let scope_label = scope_label_for(lang, settings, scope, is_owner);
+            let total = if is_owner {
+                all_clients.len()
+            } else {
+                all_clients
+                    .iter()
+                    .filter(|c| scope.admits(settings.client_group(&c.name)))
+                    .count()
+            };
             if clients.is_empty() {
-                let (text, kb) = empty_list_screen(lang, all_clients.len(), filter, is_owner, home);
+                let (text, kb) = empty_list_screen(
+                    lang,
+                    all_clients.len(),
+                    filter,
+                    is_owner,
+                    scope_label.as_deref(),
+                    home,
+                );
                 edit_or_send(bot, chat, msg_id, text, kb).await;
                 return;
             }
@@ -2585,8 +2629,13 @@ async fn render_clients_list(
             // по глобальному i, срез по странице дал бы сдвиг меток на страницах > 0.
             let expiries: Vec<Option<i64>> =
                 clients.iter().map(|c| vpn.client_expiry(&c.name)).collect();
-            let title =
-                i18n::clients_title_filtered(lang, filter, clients.len(), all_clients.len());
+            let title = i18n::clients_title_filtered(
+                lang,
+                filter,
+                scope_label.as_deref(),
+                clients.len(),
+                total,
+            );
             edit_or_send(
                 bot,
                 chat,
@@ -2601,6 +2650,7 @@ async fn render_clients_list(
                     8,
                     filter,
                     is_owner,
+                    scope_label.as_deref(),
                 ),
             )
             .await;
@@ -4441,7 +4491,7 @@ async fn callback_handler(
                 chat,
                 msg_id,
                 i18n::scope_title(lang),
-                menu::group_scope_menu(lang, &groups),
+                menu::group_scope_menu(lang, &groups, settings.owner_scope(uid)),
             )
             .await;
         }
@@ -4956,6 +5006,7 @@ mod tests {
             0,
             crate::vpn::model::ClientFilter::All,
             true,
+            None,
             home.clone(),
         );
         assert_eq!(text, i18n::clients_empty(Lang::Ru));
@@ -4971,6 +5022,7 @@ mod tests {
             3,
             crate::vpn::model::ClientFilter::All,
             true,
+            Some("family"),
             menu::main_menu(Lang::Ru),
         );
         assert_eq!(text, i18n::clients_empty_filtered(Lang::Ru));
@@ -5068,6 +5120,7 @@ mod tests {
                 8,
                 crate::vpn::model::ClientFilter::All,
                 true,
+                Some("family"),
             ),
             menu::language_select(),
             menu::settings_menu(Lang::Ru, false, false, false, false, false),
@@ -5101,8 +5154,13 @@ mod tests {
             menu::group_select_menu(Lang::Ru, &[sample_group()]),
             menu::ga_main_menu(Lang::Ru, true),
             menu::move_client_menu(Lang::Ru, "alice", &[sample_group()]),
-            menu::group_scope_menu(Lang::Ru, &[sample_group()]),
-            menu::clients_empty_menu(Lang::Ru, crate::vpn::model::ClientFilter::All, true),
+            menu::group_scope_menu(Lang::Ru, &[sample_group()], ListScope::Group(1)),
+            menu::clients_empty_menu(
+                Lang::Ru,
+                crate::vpn::model::ClientFilter::All,
+                true,
+                Some("family"),
+            ),
             menu::slug_recommend_menu(Lang::Ru),
             menu::cancel_menu(Lang::Ru),
             menu::allowed_ips_menu(

--- a/src/bot/menu.rs
+++ b/src/bot/menu.rs
@@ -159,16 +159,30 @@ pub fn move_client_menu(
 }
 
 /// Экран выбора группового фильтра списка (владелец): все / без группы / группа.
-pub fn group_scope_menu(lang: Lang, groups: &[crate::store::GroupRow]) -> InlineKeyboardMarkup {
+/// Текущий скоуп помечен ✅ — как активный статус-фильтр в `filter_row`.
+pub fn group_scope_menu(
+    lang: Lang,
+    groups: &[crate::store::GroupRow],
+    current: crate::store::ListScope,
+) -> InlineKeyboardMarkup {
+    use crate::store::ListScope;
+    let mark = |s: ListScope| if s == current { "✅ " } else { "" };
     let mut rows = vec![
-        vec![cb(&i18n::btn_scope_all(lang), "gscope:all")],
-        vec![cb(&i18n::no_group_label(lang), "gscope:none")],
+        vec![cb(
+            &format!("{}{}", mark(ListScope::All), i18n::btn_scope_all(lang)),
+            "gscope:all",
+        )],
+        vec![cb(
+            &format!("{}{}", mark(ListScope::NoGroup), i18n::no_group_label(lang)),
+            "gscope:none",
+        )],
     ];
-    rows.extend(
-        groups
-            .iter()
-            .map(|g| vec![cb(&format!("🗂 {}", g.name), &format!("gscope:{}", g.id))]),
-    );
+    rows.extend(groups.iter().map(|g| {
+        vec![cb(
+            &format!("{}🗂 {}", mark(ListScope::Group(g.id)), g.name),
+            &format!("gscope:{}", g.id),
+        )]
+    }));
     rows.push(vec![cb(&i18n::btn_back(lang), "list")]);
     InlineKeyboardMarkup::new(rows)
 }
@@ -413,6 +427,7 @@ pub fn clients_list(
     per_page: usize,
     current_filter: ClientFilter,
     is_owner: bool,
+    scope_label: Option<&str>,
 ) -> InlineKeyboardMarkup {
     if per_page == 0 {
         return InlineKeyboardMarkup::new(vec![vec![cb(&i18n::btn_back(lang), "menu")]]);
@@ -456,9 +471,10 @@ pub fn clients_list(
     rows.push(nav);
     let mut filter_btns = filter_row(lang, current_filter);
     // Кнопка «🗂» — фильтр списка по группе; видна только владельцу
-    // (групповому админу скоуп и так задаёт его текущая группа).
+    // (групповому админу скоуп и так задаёт его текущая группа). Несёт имя
+    // текущего скоупа — липкий фильтр по группе не должен быть невидимым.
     if is_owner {
-        filter_btns.push(cb(&i18n::btn_scope(lang), "gscope"));
+        filter_btns.push(cb(&i18n::btn_scope(lang, scope_label), "gscope"));
     }
     rows.push(filter_btns);
     // «Перевыпустить всех» — глобальное действие, групповому админу не
@@ -478,10 +494,11 @@ pub fn clients_empty_menu(
     lang: Lang,
     current_filter: ClientFilter,
     is_owner: bool,
+    scope_label: Option<&str>,
 ) -> InlineKeyboardMarkup {
     let mut filter_btns = filter_row(lang, current_filter);
     if is_owner {
-        filter_btns.push(cb(&i18n::btn_scope(lang), "gscope"));
+        filter_btns.push(cb(&i18n::btn_scope(lang, scope_label), "gscope"));
     }
     InlineKeyboardMarkup::new(vec![filter_btns, vec![cb(&i18n::btn_back(lang), "menu")]])
 }
@@ -853,6 +870,19 @@ mod tests {
             .collect()
     }
 
+    /// Подпись кнопки с данным callback (первое совпадение).
+    fn label_of(kb: &InlineKeyboardMarkup, data: &str) -> Option<String> {
+        kb.inline_keyboard
+            .iter()
+            .flatten()
+            .find_map(|b| match &b.kind {
+                teloxide::types::InlineKeyboardButtonKind::CallbackData(d) if d == data => {
+                    Some(b.text.clone())
+                }
+                _ => None,
+            })
+    }
+
     #[test]
     fn main_menu_has_expected_actions() {
         let data = all_callback_data(&main_menu(Lang::Ru));
@@ -950,6 +980,7 @@ mod tests {
             10,
             ClientFilter::All,
             true,
+            None,
         ));
         assert!(data.contains(&"regen_all".to_string()));
     }
@@ -978,6 +1009,7 @@ mod tests {
             10,
             ClientFilter::All,
             false,
+            None,
         ));
         assert!(
             data.contains(&"page:0".to_string()),
@@ -1000,7 +1032,17 @@ mod tests {
                 last_handshake: None,
             })
             .collect();
-        let kb = clients_list(Lang::Ru, &clients, &[], 0, 0, 8, ClientFilter::All, false);
+        let kb = clients_list(
+            Lang::Ru,
+            &clients,
+            &[],
+            0,
+            0,
+            8,
+            ClientFilter::All,
+            false,
+            None,
+        );
         // nav-ряд — первый после клиентских (8 клиентов на странице → ряд с индексом 8).
         let nav_row = &kb.inline_keyboard[8];
         let data: Vec<&str> = nav_row
@@ -1031,7 +1073,17 @@ mod tests {
                 last_handshake: None,
             })
             .collect();
-        let kb = clients_list(Lang::Ru, &clients, &[], 0, 2, 8, ClientFilter::All, false);
+        let kb = clients_list(
+            Lang::Ru,
+            &clients,
+            &[],
+            0,
+            2,
+            8,
+            ClientFilter::All,
+            false,
+            None,
+        );
         // Страница 2: клиентские ряды 16..23 (8 шт.) → nav-ряд с индексом 8.
         let nav_row = &kb.inline_keyboard[8];
         let data: Vec<&str> = nav_row
@@ -1093,6 +1145,7 @@ mod tests {
             10,
             ClientFilter::All,
             false,
+            None,
         ));
         assert!(data.contains(&"client:a".to_string()));
         assert!(data.contains(&"client:b".to_string()));
@@ -1111,6 +1164,7 @@ mod tests {
             0,
             ClientFilter::All,
             false,
+            None,
         );
         let data_empty = all_callback_data(&kb_empty);
         assert_eq!(
@@ -1142,7 +1196,17 @@ mod tests {
                 last_handshake: None,
             },
         ];
-        let kb_filled = clients_list(Lang::Ru, &clients, &[], 0, 0, 0, ClientFilter::All, false);
+        let kb_filled = clients_list(
+            Lang::Ru,
+            &clients,
+            &[],
+            0,
+            0,
+            0,
+            ClientFilter::All,
+            false,
+            None,
+        );
         let data_filled = all_callback_data(&kb_filled);
         assert_eq!(
             data_filled,
@@ -1186,6 +1250,7 @@ mod tests {
             10,
             ClientFilter::All,
             false,
+            None,
         ));
         assert!(
             texts
@@ -1247,6 +1312,7 @@ mod tests {
             10,
             ClientFilter::All,
             false,
+            None,
         ));
         assert!(
             texts.iter().any(|t| t.starts_with("🟢 online")),
@@ -1298,6 +1364,7 @@ mod tests {
             10,
             ClientFilter::All,
             false,
+            None,
         ));
         assert!(
             texts
@@ -1336,6 +1403,7 @@ mod tests {
             10,
             ClientFilter::All,
             false,
+            None,
         ));
         assert!(data.contains(&"listfilter:all".to_string()));
         assert!(data.contains(&"listfilter:online".to_string()));
@@ -1365,6 +1433,7 @@ mod tests {
             10,
             ClientFilter::Online,
             false,
+            None,
         ));
         assert!(
             texts_online
@@ -1405,6 +1474,7 @@ mod tests {
             10,
             ClientFilter::All,
             true,
+            None,
         ));
         assert!(with_scope.contains(&"gscope".to_string()));
         let without_scope = all_callback_data(&clients_list(
@@ -1416,6 +1486,7 @@ mod tests {
             10,
             ClientFilter::All,
             false,
+            None,
         ));
         assert!(!without_scope.contains(&"gscope".to_string()));
     }
@@ -1443,6 +1514,7 @@ mod tests {
             10,
             ClientFilter::All,
             true,
+            None,
         ));
         assert!(owner.contains(&"regen_all".to_string()));
         let ga = all_callback_data(&clients_list(
@@ -1454,6 +1526,7 @@ mod tests {
             10,
             ClientFilter::All,
             false,
+            None,
         ));
         assert!(!ga.contains(&"regen_all".to_string()));
     }
@@ -1478,11 +1551,78 @@ mod tests {
             max_clients: None,
             created_at: 0,
         };
-        let data = all_callback_data(&group_scope_menu(Lang::Ru, &[g]));
+        let data = all_callback_data(&group_scope_menu(
+            Lang::Ru,
+            &[g],
+            crate::store::ListScope::All,
+        ));
         assert!(data.contains(&"gscope:all".to_string()));
         assert!(data.contains(&"gscope:none".to_string()));
         assert!(data.contains(&"gscope:5".to_string()));
         assert!(data.contains(&"list".to_string()));
+    }
+
+    #[test]
+    fn group_scope_menu_marks_current_scope() {
+        use crate::store::ListScope;
+        // Текущий скоуп помечен ✅ — как активный фильтр в filter_row; иначе
+        // липкий скоуп невидим и владелец не понимает, почему клиентов «мало».
+        let g = crate::store::GroupRow {
+            id: 5,
+            name: "family".into(),
+            max_clients: None,
+            created_at: 0,
+        };
+        let kb = group_scope_menu(Lang::Ru, std::slice::from_ref(&g), ListScope::Group(5));
+        assert!(label_of(&kb, "gscope:5").unwrap().starts_with("✅ "));
+        assert!(!label_of(&kb, "gscope:all").unwrap().starts_with("✅ "));
+        assert!(!label_of(&kb, "gscope:none").unwrap().starts_with("✅ "));
+        let kb = group_scope_menu(Lang::Ru, std::slice::from_ref(&g), ListScope::NoGroup);
+        assert!(label_of(&kb, "gscope:none").unwrap().starts_with("✅ "));
+        let kb = group_scope_menu(Lang::Ru, std::slice::from_ref(&g), ListScope::All);
+        assert!(label_of(&kb, "gscope:all").unwrap().starts_with("✅ "));
+    }
+
+    #[test]
+    fn clients_list_scope_button_shows_current_scope() {
+        // Кнопка «🗂» несёт имя текущего скоупа; без скоупа — голая «🗂».
+        let clients = vec![Client {
+            name: "a".into(),
+            ip: String::new(),
+            client_ipv6: String::new(),
+            status: String::new(),
+            status_code: "active".into(),
+            rx: 0,
+            tx: 0,
+            last_handshake: None,
+        }];
+        let kb = clients_list(
+            Lang::Ru,
+            &clients,
+            &[],
+            0,
+            0,
+            10,
+            ClientFilter::All,
+            true,
+            Some("family"),
+        );
+        assert_eq!(label_of(&kb, "gscope").unwrap(), "🗂 family");
+        let kb = clients_list(
+            Lang::Ru,
+            &clients,
+            &[],
+            0,
+            0,
+            10,
+            ClientFilter::All,
+            true,
+            None,
+        );
+        assert_eq!(label_of(&kb, "gscope").unwrap(), "🗂");
+        // Пустая выборка — та же индикация.
+        let kb = clients_empty_menu(Lang::Ru, ClientFilter::All, true, Some("family"));
+        assert_eq!(label_of(&kb, "gscope").unwrap(), "🗂 family");
     }
 
     #[test]
@@ -1780,7 +1920,7 @@ mod tests {
         // Тупик #20: пустая выборка при липком фильтре/скоупе обязана
         // оставлять кнопки смены статус-фильтра и группового фильтра —
         // иначе «Без группы» без клиентов запирает раздел клиентов.
-        let data = all_callback_data(&clients_empty_menu(Lang::Ru, ClientFilter::All, true));
+        let data = all_callback_data(&clients_empty_menu(Lang::Ru, ClientFilter::All, true, None));
         assert!(data.contains(&"gscope".to_string()));
         assert!(data.contains(&"listfilter:all".to_string()));
         assert!(data.contains(&"menu".to_string()));
@@ -1788,7 +1928,12 @@ mod tests {
 
     #[test]
     fn clients_empty_menu_hides_scope_for_group_admin() {
-        let data = all_callback_data(&clients_empty_menu(Lang::Ru, ClientFilter::All, false));
+        let data = all_callback_data(&clients_empty_menu(
+            Lang::Ru,
+            ClientFilter::All,
+            false,
+            None,
+        ));
         assert!(!data.contains(&"gscope".to_string()));
         assert!(data.contains(&"listfilter:all".to_string()));
     }

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -530,28 +530,42 @@ pub fn clients_title(lang: Lang) -> String {
 /// Заголовок списка клиентов с индикатором активного фильтра.
 /// `All` (или когда показаны все) → без пометки (как `clients_title`).
 /// Иначе → «👥 Клиенты — 🟢 онлайн (3 из 10)».
+/// Заголовок списка клиентов. `scope_label` — имя группового скоупа
+/// владельца («family», «Без группы»), `None` — все группы. Скоуп показывается
+/// всегда, когда задан: липкий фильтр по группе иначе невидим, и список из
+/// одного клиента выглядит как «все клиенты сервера». Статус-фильтр
+/// показывается, только если он реально что-то отсёк.
 pub fn clients_title_filtered(
     lang: Lang,
     filter: crate::vpn::model::ClientFilter,
+    scope_label: Option<&str>,
     shown: usize,
     total: usize,
 ) -> String {
-    if matches!(filter, crate::vpn::model::ClientFilter::All) || shown == total {
+    let mut parts: Vec<String> = Vec::new();
+    if let Some(scope) = scope_label {
+        parts.push(format!("🗂 {}", html_escape(scope)));
+    }
+    if !matches!(filter, crate::vpn::model::ClientFilter::All) && shown != total {
+        let mark = filter.mark();
+        let label = match (lang, filter) {
+            (Lang::Ru, crate::vpn::model::ClientFilter::Online) => "онлайн",
+            (Lang::En, crate::vpn::model::ClientFilter::Online) => "online",
+            (Lang::Ru, crate::vpn::model::ClientFilter::Offline) => "оффлайн",
+            (Lang::En, crate::vpn::model::ClientFilter::Offline) => "offline",
+            (Lang::Ru, crate::vpn::model::ClientFilter::Never) => "никогда",
+            (Lang::En, crate::vpn::model::ClientFilter::Never) => "never",
+            _ => "",
+        };
+        parts.push(format!("{mark} {label}"));
+    }
+    if parts.is_empty() {
         return clients_title(lang);
     }
-    let mark = filter.mark();
-    let label = match (lang, filter) {
-        (Lang::Ru, crate::vpn::model::ClientFilter::Online) => "онлайн",
-        (Lang::En, crate::vpn::model::ClientFilter::Online) => "online",
-        (Lang::Ru, crate::vpn::model::ClientFilter::Offline) => "оффлайн",
-        (Lang::En, crate::vpn::model::ClientFilter::Offline) => "offline",
-        (Lang::Ru, crate::vpn::model::ClientFilter::Never) => "никогда",
-        (Lang::En, crate::vpn::model::ClientFilter::Never) => "never",
-        _ => "",
-    };
+    let parts = parts.join(" · ");
     match lang {
-        Lang::Ru => format!("👥 <b>Клиенты</b> — {mark} {label} ({shown} из {total})"),
-        Lang::En => format!("👥 <b>Clients</b> — {mark} {label} ({shown} of {total})"),
+        Lang::Ru => format!("👥 <b>Клиенты</b> — {parts} ({shown} из {total})"),
+        Lang::En => format!("👥 <b>Clients</b> — {parts} ({shown} of {total})"),
     }
 }
 pub fn not_found(lang: Lang) -> String {
@@ -2338,10 +2352,14 @@ pub fn scope_title(lang: Lang) -> String {
     .to_string()
 }
 /// Кнопка «🗂» в ряду фильтров списка клиентов — открывает `scope_title`
-/// (только владельцу, см. `menu::clients_list`'s `can_scope`).
-pub fn btn_scope(lang: Lang) -> String {
+/// (только владельцу, см. `menu::clients_list`). Несёт имя текущего скоупа,
+/// чтобы липкий фильтр по группе был виден прямо в списке.
+pub fn btn_scope(lang: Lang, scope_label: Option<&str>) -> String {
     let _ = lang;
-    "🗂".to_string()
+    match scope_label {
+        Some(name) => format!("🗂 {name}"),
+        None => "🗂".to_string(),
+    }
 }
 pub fn btn_scope_all(lang: Lang) -> String {
     match lang {
@@ -2893,8 +2911,8 @@ mod tests {
     fn clients_title_all_has_no_filter_label() {
         use crate::vpn::model::ClientFilter;
         // All → как clients_title, без пометки фильтра.
-        let ru = clients_title_filtered(Lang::Ru, ClientFilter::All, 5, 10);
-        let en = clients_title_filtered(Lang::En, ClientFilter::All, 5, 10);
+        let ru = clients_title_filtered(Lang::Ru, ClientFilter::All, None, 5, 10);
+        let en = clients_title_filtered(Lang::En, ClientFilter::All, None, 5, 10);
         assert_eq!(ru, "👥 <b>Клиенты</b>:");
         assert_eq!(en, "👥 <b>Clients</b>:");
     }
@@ -2902,11 +2920,11 @@ mod tests {
     #[test]
     fn clients_title_filtered_shows_label_and_count() {
         use crate::vpn::model::ClientFilter;
-        let ru = clients_title_filtered(Lang::Ru, ClientFilter::Online, 3, 10);
+        let ru = clients_title_filtered(Lang::Ru, ClientFilter::Online, None, 3, 10);
         assert!(ru.contains("🟢"));
         assert!(ru.contains("онлайн"));
         assert!(ru.contains("(3 из 10)"));
-        let en = clients_title_filtered(Lang::En, ClientFilter::Never, 2, 8);
+        let en = clients_title_filtered(Lang::En, ClientFilter::Never, None, 2, 8);
         assert!(en.contains("🟡"));
         assert!(en.contains("never"));
         assert!(en.contains("(2 of 8)"));
@@ -2916,8 +2934,35 @@ mod tests {
     fn clients_title_filtered_shown_equals_total_drops_label() {
         use crate::vpn::model::ClientFilter;
         // Фильтр активен, но показаны все (напр. 3 из 3 онлайн) → без пометки.
-        let ru = clients_title_filtered(Lang::Ru, ClientFilter::Online, 3, 3);
+        let ru = clients_title_filtered(Lang::Ru, ClientFilter::Online, None, 3, 3);
         assert_eq!(ru, "👥 <b>Клиенты</b>:");
+    }
+
+    #[test]
+    fn clients_title_scoped_shows_group_and_count() {
+        use crate::vpn::model::ClientFilter;
+        // Групповой скоуп владельца обязан быть виден в заголовке даже при
+        // фильтре «Все»: иначе список из одного клиента выглядит как «все
+        // клиенты сервера» (реальный кейс: 1 показан, 4 на сервере).
+        let ru = clients_title_filtered(Lang::Ru, ClientFilter::All, Some("family"), 1, 4);
+        assert!(ru.contains("🗂 family"), "{ru}");
+        assert!(ru.contains("(1 из 4)"), "{ru}");
+        // Скоуп показывается и когда в группе все клиенты сервера.
+        let full = clients_title_filtered(Lang::En, ClientFilter::All, Some("family"), 4, 4);
+        assert!(full.contains("🗂 family"), "{full}");
+        assert!(full.contains("(4 of 4)"), "{full}");
+        // Скоуп + статус-фильтр — обе пометки.
+        let both = clients_title_filtered(Lang::Ru, ClientFilter::Online, Some("family"), 1, 4);
+        assert!(both.contains("🗂 family"), "{both}");
+        assert!(both.contains("🟢 онлайн"), "{both}");
+        // Имя группы экранируется (HTML parse mode).
+        let esc = clients_title_filtered(Lang::Ru, ClientFilter::All, Some("<x>"), 1, 4);
+        assert!(esc.contains("&lt;x&gt;"), "{esc}");
+        // Без скоупа и без фильтра — прежний короткий заголовок.
+        assert_eq!(
+            clients_title_filtered(Lang::Ru, ClientFilter::All, None, 4, 4),
+            "👥 <b>Клиенты</b>:"
+        );
     }
 
     #[test]

--- a/src/store/settings.rs
+++ b/src/store/settings.rs
@@ -133,9 +133,16 @@ impl Store {
     }
     /// Фильтр списка клиентов по группе — для владельцев (групповым админам
     /// скоуп диктует их текущая группа).
+    /// Липкий групповой скоуп списка владельца. Скоуп на удалённую группу
+    /// считается `All`: иначе он навсегда прячет всех клиентов за экраном
+    /// «под фильтр никто не попал».
     pub fn owner_scope(&self, uid: i64) -> crate::store::ListScope {
-        self.get_json(&format!("owner_scope:{uid}"))
-            .unwrap_or(crate::store::ListScope::All)
+        use crate::store::ListScope;
+        match self.get_json(&format!("owner_scope:{uid}")) {
+            Some(ListScope::Group(g)) if self.group(g).is_none() => ListScope::All,
+            Some(s) => s,
+            None => ListScope::All,
+        }
     }
     pub fn set_owner_scope(&self, uid: i64, s: crate::store::ListScope) {
         self.set_json(&format!("owner_scope:{uid}"), &s);
@@ -475,10 +482,26 @@ mod tests {
         use crate::store::ListScope;
         let s = Store::open_in_memory();
         assert_eq!(s.owner_scope(42), ListScope::All);
-        s.set_owner_scope(42, ListScope::Group(7));
-        assert_eq!(s.owner_scope(42), ListScope::Group(7));
+        // Скоуп на существующую группу читается как есть (на несуществующую —
+        // см. owner_scope_falls_back_to_all_when_group_deleted).
+        let gid = s.create_group("family", 0).unwrap();
+        s.set_owner_scope(42, ListScope::Group(gid));
+        assert_eq!(s.owner_scope(42), ListScope::Group(gid));
         s.set_owner_scope(42, ListScope::NoGroup);
         assert_eq!(s.owner_scope(42), ListScope::NoGroup);
+    }
+
+    #[test]
+    fn owner_scope_falls_back_to_all_when_group_deleted() {
+        use crate::store::ListScope;
+        // Липкий скоуп на удалённую группу иначе навсегда прячет всех
+        // клиентов за экраном «под фильтр никто не попал».
+        let s = Store::open_in_memory();
+        let gid = s.create_group("family", 0).unwrap();
+        s.set_owner_scope(42, ListScope::Group(gid));
+        assert_eq!(s.owner_scope(42), ListScope::Group(gid));
+        s.delete_group(gid);
+        assert_eq!(s.owner_scope(42), ListScope::All);
     }
 
     #[test]


### PR DESCRIPTION
## Суть

Владелец видел в списке одного клиента из четырёх, при этом «Проверка» честно показывала четырёх. Причина: липкий групповой фильтр списка. Его ставят кнопка «🗂» в ряду фильтров и «👥 Клиенты группы» в карточке группы, и он сохраняется в настройках владельца навсегда. Ничто на экране этого не показывало: заголовок оставался «Клиенты:», статус-фильтр «✅ Все», кнопка «🗂» без состояния, на экране «Показывать клиентов» текущий пункт не отмечался.

## Что сделано

- **Заголовок списка показывает скоуп и счётчик**: «👥 Клиенты — 🗂 family (1 из 4)». Скоуп показывается всегда, когда задан, даже если группа содержит всех клиентов сервера; статус-фильтр, как и раньше, только если он что-то отсёк. Оба вместе: «🗂 family · 🟢 онлайн (1 из 4)». Имя группы экранируется.
- **Кнопка «🗂» несёт имя текущего скоупа** («🗂 family», «🗂 Без группы»), в том числе на экране пустой выборки.
- **Экран «Показывать клиентов» отмечает текущий пункт ✅**, как это делает ряд статус-фильтров.
- **Скоуп на удалённую группу читается как «Все группы»** прямо в `Store::owner_scope`, так что все потребители (список, статистика) не упираются в вечный экран «под фильтр никто не попал».
- **Групповой админ**: подписи скоупа нет, а «всего» в заголовке считается по его группе, а не по всему серверу. Раньше счётчик «из N» при статус-фильтре раскрывал ему число клиентов всего сервера.

## Тесты

- Заголовок: группа + счётчик, «4 из 4» со скоупом, скоуп + статус-фильтр, экранирование, прежний короткий заголовок без скоупа.
- Меню: ✅ на текущем пункте для All / NoGroup / Group, имя группы на кнопке «🗂» в списке и в пустой выборке.
- Store: скоуп на удалённую группу схлопывается в All; roundtrip теперь на существующей группе.
- `cargo test` — 503 зелёных, `cargo clippy --all-targets` чист.
